### PR TITLE
Optional burnStateMask in TokenSplit.split + tolerant CertificationResponse parsing

### DIFF
--- a/src/api/CertificationResponse.ts
+++ b/src/api/CertificationResponse.ts
@@ -28,22 +28,27 @@ export enum CertificationStatus {
  * JSON shape of a certification response.
  */
 export interface ICertificationResponseJson {
-  readonly status: CertificationStatus;
+  readonly status: string;
 }
 
 /**
  * Response object returned by the aggregator on certification request.
+ *
+ * The status is deliberately tolerant: the aggregator may emit status strings unknown to this SDK
+ * version (older deployments, or statuses added later). An unknown status parses successfully and
+ * must be treated by callers as "the request was not accepted" — the caller then probes
+ * `getInclusionProof` to learn the state's actual certification, instead of failing on parse.
  */
 export class CertificationResponse {
-  public constructor(public readonly status: CertificationStatus) {}
+  public constructor(public readonly status: CertificationStatus | (string & {})) {}
 
   /**
    * Create a new certification response.
-   * @param {CertificationStatus} status Certification response status
+   * @param {CertificationStatus | string} status Certification response status (unknown strings allowed — see class doc)
    *
    * @returns {CertificationResponse} Created certification response
    */
-  public static create(status: CertificationStatus): CertificationResponse {
+  public static create(status: CertificationStatus | (string & {})): CertificationResponse {
     return new CertificationResponse(status);
   }
 
@@ -74,7 +79,7 @@ export class CertificationResponse {
       data !== null &&
       'status' in data &&
       typeof data.status === 'string' &&
-      !!CertificationStatus[data.status as keyof typeof CertificationStatus]
+      data.status.length > 0
     );
   }
 

--- a/src/api/CertificationResponse.ts
+++ b/src/api/CertificationResponse.ts
@@ -40,15 +40,17 @@ export interface ICertificationResponseJson {
  * `getInclusionProof` to learn the state's actual certification, instead of failing on parse.
  */
 export class CertificationResponse {
-  public constructor(public readonly status: CertificationStatus | (string & {})) {}
+  /** The aggregator's status string. Known values are enumerated in {@link CertificationStatus};
+   * compare against those members. Unknown strings are preserved as-is. */
+  public constructor(public readonly status: string) {}
 
   /**
    * Create a new certification response.
-   * @param {CertificationStatus | string} status Certification response status (unknown strings allowed — see class doc)
+   * @param {string} status Certification response status (unknown strings allowed — see class doc)
    *
    * @returns {CertificationResponse} Created certification response
    */
-  public static create(status: CertificationStatus | (string & {})): CertificationResponse {
+  public static create(status: string): CertificationResponse {
     return new CertificationResponse(status);
   }
 

--- a/src/payment/TokenSplit.ts
+++ b/src/payment/TokenSplit.ts
@@ -51,6 +51,9 @@ export class TokenSplit {
     requests: SplitTokenRequest[],
     burnStateMask?: Uint8Array,
   ): Promise<ISplit> {
+    if (burnStateMask !== undefined && burnStateMask.length !== 32) {
+      throw new RangeError('The burnStateMask must be exactly 32 bytes long.');
+    }
     const hasher = new DataHasherFactory(HashAlgorithm.SHA256, DataHasher);
     const trees = new Map<string, [AssetId, SparseMerkleSumTree]>();
     const networkId = token.genesis.networkId;

--- a/src/payment/TokenSplit.ts
+++ b/src/payment/TokenSplit.ts
@@ -40,12 +40,16 @@ export class TokenSplit {
    * @param {Token} token Source token to split.
    * @param {(bytes: Uint8Array) => Promise<IPaymentData>} decodePaymentData Decoder for the source token's payment data.
    * @param {SplitTokenRequest[]} requests Per-output mint requests.
+   * @param {Uint8Array} [burnStateMask] State mask for the burn transaction. Defaults to a random
+   *   value; callers needing a crash-resumable (re-buildable) split supply a deterministically
+   *   derived mask so the identical burn transaction can be reconstructed after a failure.
    * @returns {Promise<ISplit>} Burn transaction and split tokens ready to mint.
    */
   public static async split(
     token: Token,
     decodePaymentData: (bytes: Uint8Array) => Promise<IPaymentData>,
     requests: SplitTokenRequest[],
+    burnStateMask?: Uint8Array,
   ): Promise<ISplit> {
     const hasher = new DataHasherFactory(HashAlgorithm.SHA256, DataHasher);
     const trees = new Map<string, [AssetId, SparseMerkleSumTree]>();
@@ -106,7 +110,7 @@ export class TokenSplit {
     const burnTransaction = await TransferTransaction.create(
       token,
       burnPredicate,
-      crypto.getRandomValues(new Uint8Array(32)),
+      burnStateMask ?? crypto.getRandomValues(new Uint8Array(32)),
     );
 
     const tokens: SplitToken[] = Array.from(requestsWithTokenId.values()).map(

--- a/tests/examples/split/ExampleTest.ts
+++ b/tests/examples/split/ExampleTest.ts
@@ -58,7 +58,7 @@ it('Token splitting', async () => {
   );
 
   let response = await client.submitCertificationRequest(await CertificationData.fromMintTransaction(mintTransaction));
-  if (response.status !== CertificationStatus.SUCCESS) {
+  if (response.status !== String(CertificationStatus.SUCCESS)) {
     throw new Error(`Token mint certification failed: ${response.status}`);
   }
 
@@ -97,7 +97,7 @@ it('Token splitting', async () => {
     ),
   );
 
-  if (response.status !== CertificationStatus.SUCCESS) {
+  if (response.status !== String(CertificationStatus.SUCCESS)) {
     throw new Error(`Token certification failed: ${response.status}`);
   }
 
@@ -127,7 +127,7 @@ it('Token splitting', async () => {
     const certificationData = await CertificationData.fromMintTransaction(mintTransaction);
 
     const response = await client.submitCertificationRequest(certificationData);
-    if (response.status !== CertificationStatus.SUCCESS) {
+    if (response.status !== String(CertificationStatus.SUCCESS)) {
       throw new Error(`Token certification failed: ${response.status}`);
     }
 

--- a/tests/examples/transfer/ExampleTest.ts
+++ b/tests/examples/transfer/ExampleTest.ts
@@ -87,7 +87,7 @@ it('Token transfer', async () => {
 
   const response = await client.submitCertificationRequest(certificationData);
 
-  if (response.status !== CertificationStatus.SUCCESS) {
+  if (response.status !== String(CertificationStatus.SUCCESS)) {
     throw new Error(`Token certification failed: ${response.status}`);
   }
 

--- a/tests/functional/payment/SplitBuilderTest.ts
+++ b/tests/functional/payment/SplitBuilderTest.ts
@@ -20,6 +20,7 @@ import { StateTransitionClient } from '../../../src/StateTransitionClient.js';
 import { MintTransaction } from '../../../src/transaction/MintTransaction.js';
 import { Token } from '../../../src/transaction/Token.js';
 import { MintJustificationVerifierService } from '../../../src/transaction/verification/MintJustificationVerifierService.js';
+import { HexConverter } from '../../../src/util/HexConverter.js';
 import { waitInclusionProof } from '../../../src/util/InclusionProofUtils.js';
 import { VerificationStatus } from '../../../src/verification/VerificationStatus.js';
 import { TestAggregatorClient } from '../TestAggregatorClient.js';
@@ -142,5 +143,51 @@ describe('SplitBuilder Functional Test', () => {
           .then((result) => result.status),
       ).resolves.toEqual(VerificationStatus.OK);
     }
+  });
+
+  it('should rebuild a byte-identical burn transaction from a caller-supplied burn state mask', async () => {
+    const aggregatorClient = TestAggregatorClient.create();
+    const trustBase = aggregatorClient.rootTrustBase;
+    const client = new StateTransitionClient(aggregatorClient);
+    const predicateVerifier = PredicateVerifierService.create();
+    const mintJustificationVerifier = new MintJustificationVerifierService();
+    mintJustificationVerifier.register(
+      new SplitMintJustificationVerifier(trustBase, predicateVerifier, TestPaymentData.decode),
+    );
+
+    const signingService = new SigningService(SigningService.generatePrivateKey());
+    const predicate = SignaturePredicate.fromSigningService(signingService);
+    const assets = [new Asset(new AssetId(crypto.getRandomValues(new Uint8Array(10))), 500n)];
+    const paymentData = new TestPaymentData(PaymentAssetCollection.create(...assets));
+    const mintTransaction = await MintTransaction.create(NetworkId.LOCAL, predicate, await paymentData.encode());
+
+    const response = await client.submitCertificationRequest(
+      await CertificationData.fromMintTransaction(mintTransaction),
+    );
+    expect(response.status).toEqual(CertificationStatus.SUCCESS);
+
+    const token = await Token.mint(
+      trustBase,
+      predicateVerifier,
+      mintJustificationVerifier,
+      await mintTransaction.toCertifiedTransaction(
+        trustBase,
+        predicateVerifier,
+        await waitInclusionProof(client, trustBase, predicateVerifier, mintTransaction),
+      ),
+    );
+
+    // Identical requests across all calls; only the burn mask determines reproducibility.
+    const requests = [SplitTokenRequest.create(predicate, PaymentAssetCollection.create(assets[0]))];
+    const burnStateMask = crypto.getRandomValues(new Uint8Array(32));
+
+    const first = await TokenSplit.split(token, TestPaymentData.decode, requests, burnStateMask);
+    const second = await TokenSplit.split(token, TestPaymentData.decode, requests, burnStateMask);
+    const defaulted = await TokenSplit.split(token, TestPaymentData.decode, requests);
+
+    const firstBurn = HexConverter.encode(first.burn.transaction.toCBOR());
+    expect(HexConverter.encode(second.burn.transaction.toCBOR())).toEqual(firstBurn);
+    // The default stays random — omitting the mask must not become deterministic.
+    expect(HexConverter.encode(defaulted.burn.transaction.toCBOR())).not.toEqual(firstBurn);
   });
 });

--- a/tests/functional/payment/SplitBuilderTest.ts
+++ b/tests/functional/payment/SplitBuilderTest.ts
@@ -189,5 +189,10 @@ describe('SplitBuilder Functional Test', () => {
     expect(HexConverter.encode(second.burn.transaction.toCBOR())).toEqual(firstBurn);
     // The default stays random — omitting the mask must not become deterministic.
     expect(HexConverter.encode(defaulted.burn.transaction.toCBOR())).not.toEqual(firstBurn);
+
+    // A mask of the wrong length is a caller bug — rejected before any work.
+    await expect(
+      TokenSplit.split(token, TestPaymentData.decode, requests, crypto.getRandomValues(new Uint8Array(31))),
+    ).rejects.toThrow(RangeError);
   });
 });

--- a/tests/unit/api/CertificationResponseTest.ts
+++ b/tests/unit/api/CertificationResponseTest.ts
@@ -30,5 +30,20 @@ describe('CertificationResponse', () => {
     expect(() => CertificationResponse.fromJSON({})).toThrow(InvalidJsonStructureError);
     expect(() => CertificationResponse.fromJSON(null)).toThrow(InvalidJsonStructureError);
     expect(() => CertificationResponse.fromJSON({ status: 123 })).toThrow(InvalidJsonStructureError);
+    expect(() => CertificationResponse.fromJSON({ status: '' })).toThrow(InvalidJsonStructureError);
+  });
+
+  it('should tolerate status strings unknown to this SDK version', () => {
+    // An aggregator may emit statuses this SDK version does not know (older deployments emitting
+    // since-removed statuses, or statuses added later). Parsing must not throw; callers treat an
+    // unknown status as "not accepted" and probe the inclusion proof instead.
+    expect(CertificationResponse.isJSON({ status: 'STATE_ID_EXISTS' })).toBe(true);
+
+    const response = CertificationResponse.fromJSON({ status: 'STATE_ID_EXISTS' });
+    expect(response.status).toBe('STATE_ID_EXISTS');
+    expect(response.status).not.toBe(CertificationStatus.SUCCESS);
+
+    // Round-trips through JSON unchanged.
+    expect(CertificationResponse.fromJSON(response.toJSON()).status).toBe('STATE_ID_EXISTS');
   });
 });

--- a/tests/utils/TokenUtils.ts
+++ b/tests/utils/TokenUtils.ts
@@ -42,7 +42,7 @@ export async function mintToken(
   const certificationData = await CertificationData.fromMintTransaction(transaction);
 
   const response = await client.submitCertificationRequest(certificationData);
-  if (response.status !== CertificationStatus.SUCCESS) {
+  if (response.status !== String(CertificationStatus.SUCCESS)) {
     throw new Error(`Certification Request failed with status '${response.status}'`);
   }
 
@@ -100,7 +100,7 @@ export async function transferTokenWithTransaction(
     await CertificationData.fromTransaction(transaction, unlockScript),
   );
 
-  if (response.status !== CertificationStatus.SUCCESS) {
+  if (response.status !== String(CertificationStatus.SUCCESS)) {
     throw new Error(`Certification Request failed with status '${response.status}'`);
   }
 


### PR DESCRIPTION
Closes #124

Two changes for the wallet-api program's recoverable engine (one rc release can cover both):

1. **`burnStateMask?: Uint8Array` on `TokenSplit.split`** — default random (backward compatible). The burn transaction's state mask was the last internally generated random preventing a crash-resumable split: a caller that derives the mask deterministically (HKDF from wallet key + transferId) can now rebuild the byte-identical burn transaction after a failure and recover via `getInclusionProof` + match-verify.

2. **Tolerant `CertificationResponse` parsing** — `fromJSON` no longer throws `InvalidJsonStructureError` on status strings outside the enum. Deployed aggregators still emit `STATE_ID_EXISTS` (removed from the enum in aef6ffa/#115) until their own removal lands; an unknown status now parses and is treated by callers as "not accepted — probe the inclusion proof". Transitional by design: stays harmless after the aggregator catches up, and also future-proofs against statuses added later. The status type is `CertificationStatus | (string & {})` so existing enum comparisons keep a shared enum type (lint-verified).

**Verification:** full suite 58/58 green (2 new tests: unknown-status parse/round-trip + empty-status rejection; byte-identical burn tx from a fixed mask with the random default preserved); lint + build clean; both changes verified through the packed `lib/` artifact shape.

Review + rc publish: deferred to maintainers per program decision (wallet-api owner, 2026-06-11) — please sanity-check the tolerant-parsing direction against the post-#115 aggregator roadmap.