### PR TITLE
fix: make waitInclusionProof always settle at its deadline (#140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,18 @@ Run the example flows (requires a reachable aggregator; URL is read from each ex
 npm run test:examples
 ```
 
-Run the end-to-end suite (expects a local aggregator at `http://localhost:3000` — see [`tests/e2e/E2ETransitionFlowTest.ts`](./tests/e2e/E2ETransitionFlowTest.ts)):
+Run the end-to-end suite (defaults to a local aggregator at `http://localhost:3000`):
 
 ```bash
+npm run test:e2e
+```
+
+To run it against another network, point it at that endpoint and supply the matching trust base:
+
+```bash
+AGGREGATOR_URL=https://gateway.example.unicity.network \
+TRUST_BASE_PATH=/path/to/trust-base.json \
+AGGREGATOR_API_KEY=<key, if the endpoint requires one> \
 npm run test:e2e
 ```
 
@@ -135,8 +144,13 @@ npm run lint:fix
 
 ## Network Configuration
 
-- **Test Gateway**: `https://gateway-test.unicity.network`
-- **Network identifiers**: `NetworkId.MAINNET`, `NetworkId.TESTNET`, `NetworkId.LOCAL`
+- **Test gateway**: `https://gateway.testnet2.unicity.network`. It fronts a sharded aggregator, so a
+  plain `AggregatorClient` pointed at that one URL is enough. `certification_request` requires an API
+  key (`AggregatorClient`'s second argument); reading inclusion proofs does not.
+- **Trust base**: network-specific, and the network the SDK mints on is taken from it
+  (`trustBase.networkId`), so the trust base and the gateway must belong to the same network.
+- **Network identifiers**: `NetworkId.MAINNET`, `NetworkId.TESTNET` and `NetworkId.LOCAL` are the
+  named constants; any other id a trust base carries resolves through `NetworkId.fromId()`.
 - **Token type**: caller-supplied; use `TokenType.generate()` or construct from explicit bytes
 
 ## Unicity Signature Standard
@@ -171,7 +185,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 - **Repository**: [GitHub](https://github.com/unicitynetwork/state-transition-sdk-js)
 - **Issues**: [GitHub Issues](https://github.com/unicitynetwork/state-transition-sdk-js/issues)
-- **Gateway API**: `https://gateway-test.unicity.network`
+- **Gateway API**: `https://gateway.testnet2.unicity.network`
 
 ---
 

--- a/src/StateTransitionClient.ts
+++ b/src/StateTransitionClient.ts
@@ -2,6 +2,7 @@ import { CertificationData } from './api/CertificationData.js';
 import { CertificationResponse } from './api/CertificationResponse.js';
 import { IAggregatorClient } from './api/IAggregatorClient.js';
 import { InclusionProofResponse } from './api/InclusionProofResponse.js';
+import { IRequestOptions } from './api/IRequestOptions.js';
 import { StateId } from './api/StateId.js';
 
 /**
@@ -16,19 +17,24 @@ export class StateTransitionClient {
    * Retrieve the inclusion proof for a given state id.
    *
    * @param {StateId} stateId State id whose inclusion proof to retrieve.
+   * @param {IRequestOptions} options Optional per-request options, e.g. an abort signal.
    * @returns {Promise<InclusionProofResponse>} Inclusion proof response from the aggregator.
    */
-  public getInclusionProof(stateId: StateId): Promise<InclusionProofResponse> {
-    return this.client.getInclusionProof(stateId);
+  public getInclusionProof(stateId: StateId, options?: IRequestOptions): Promise<InclusionProofResponse> {
+    return this.client.getInclusionProof(stateId, options);
   }
 
   /**
    * Submit a certification request derived from the given certification data.
    *
    * @param {CertificationData} certificationData Certification data to submit.
+   * @param {IRequestOptions} options Optional per-request options, e.g. an abort signal.
    * @returns {Promise<CertificationResponse>} Certification response from the aggregator.
    */
-  public submitCertificationRequest(certificationData: CertificationData): Promise<CertificationResponse> {
-    return this.client.submitCertificationRequest(certificationData);
+  public submitCertificationRequest(
+    certificationData: CertificationData,
+    options?: IRequestOptions,
+  ): Promise<CertificationResponse> {
+    return this.client.submitCertificationRequest(certificationData, options);
   }
 }

--- a/src/api/AggregatorClient.ts
+++ b/src/api/AggregatorClient.ts
@@ -3,6 +3,7 @@ import { CertificationRequest } from './CertificationRequest.js';
 import { CertificationResponse } from './CertificationResponse.js';
 import { IAggregatorClient } from './IAggregatorClient.js';
 import { InclusionProofResponse } from './InclusionProofResponse.js';
+import { IRequestOptions } from './IRequestOptions.js';
 import { JsonRpcHttpTransport } from './json-rpc/JsonRpcHttpTransport.js';
 import { StateId } from './StateId.js';
 import { HexConverter } from '../util/HexConverter.js';
@@ -35,10 +36,12 @@ export class AggregatorClient implements IAggregatorClient {
   /**
    * @inheritDoc
    */
-  public async getInclusionProof(stateId: StateId): Promise<InclusionProofResponse> {
+  public async getInclusionProof(stateId: StateId, options?: IRequestOptions): Promise<InclusionProofResponse> {
     const data = { stateId: HexConverter.encode(stateId.data) };
     return InclusionProofResponse.fromCBOR(
-      HexConverter.decode((await this.transport.request('get_inclusion_proof.v2', data)) as string),
+      HexConverter.decode(
+        (await this.transport.request('get_inclusion_proof.v2', data, new Headers(), options)) as string,
+      ),
     );
   }
 
@@ -66,7 +69,10 @@ export class AggregatorClient implements IAggregatorClient {
   /**
    * @inheritDoc
    */
-  public async submitCertificationRequest(certificationData: CertificationData): Promise<CertificationResponse> {
+  public async submitCertificationRequest(
+    certificationData: CertificationData,
+    options?: IRequestOptions,
+  ): Promise<CertificationResponse> {
     const request = await CertificationRequest.create(certificationData);
 
     const headers = new Headers([['X-State-ID', HexConverter.encode(request.stateId.data)]]);
@@ -78,6 +84,7 @@ export class AggregatorClient implements IAggregatorClient {
       'certification_request',
       HexConverter.encode(request.toCBOR()),
       headers,
+      options,
     );
 
     return CertificationResponse.fromJSON(response);

--- a/src/api/IAggregatorClient.ts
+++ b/src/api/IAggregatorClient.ts
@@ -1,6 +1,7 @@
 import { CertificationData } from './CertificationData.js';
 import { CertificationResponse } from './CertificationResponse.js';
 import { InclusionProofResponse } from './InclusionProofResponse.js';
+import { IRequestOptions } from './IRequestOptions.js';
 import { StateId } from './StateId.js';
 
 /**
@@ -11,15 +12,20 @@ export interface IAggregatorClient {
    * Retrieve an inclusion proof for the given state id.
    *
    * @param {StateId} stateId State identifier to query.
+   * @param {IRequestOptions} options Optional per-request options, e.g. an abort signal.
    * @returns {Promise<InclusionProofResponse>} Inclusion proof response from the aggregator.
    */
-  getInclusionProof(stateId: StateId): Promise<InclusionProofResponse>;
+  getInclusionProof(stateId: StateId, options?: IRequestOptions): Promise<InclusionProofResponse>;
 
   /**
    * Submit a transaction commitment for inclusion in the ledger.
    *
    * @param {CertificationData} certificationData Certification data to submit.
+   * @param {IRequestOptions} options Optional per-request options, e.g. an abort signal.
    * @returns {Promise<CertificationResponse>} Certification response from the aggregator.
    */
-  submitCertificationRequest(certificationData: CertificationData): Promise<CertificationResponse>;
+  submitCertificationRequest(
+    certificationData: CertificationData,
+    options?: IRequestOptions,
+  ): Promise<CertificationResponse>;
 }

--- a/src/api/IRequestOptions.ts
+++ b/src/api/IRequestOptions.ts
@@ -1,0 +1,11 @@
+/**
+ * Per-request options accepted by aggregator client methods.
+ */
+export interface IRequestOptions {
+  /**
+   * Signal that cancels the request. Implementations performing network I/O
+   * should forward it to the underlying transport so that an abandoned request
+   * is released instead of running to completion.
+   */
+  readonly signal?: AbortSignal;
+}

--- a/src/api/json-rpc/JsonRpcHttpTransport.ts
+++ b/src/api/json-rpc/JsonRpcHttpTransport.ts
@@ -4,6 +4,7 @@ import { IJsonRpcResponse } from './IJsonRpcResponse.js';
 import { JsonRpcDataError } from './JsonRpcDataError.js';
 import { JsonRpcNetworkError } from './JsonRpcNetworkError.js';
 import { JsonRpcResponseError } from './JsonRpcResponseError.js';
+import { IRequestOptions } from '../IRequestOptions.js';
 
 /**
  * JSON-RPC HTTP service.
@@ -67,12 +68,18 @@ export class JsonRpcHttpTransport {
    * @param {string} method JSON-RPC method.
    * @param {unknown} params JSON-RPC params.
    * @param {Headers} headers Optional request headers.
+   * @param {IRequestOptions} options Optional per-request options, e.g. an abort signal.
    * @returns {Promise<unknown>} The response result.
    * @throws {JsonRpcNetworkError} On a non-success HTTP status.
    * @throws {JsonRpcDataError} When the response carries a JSON-RPC error object.
    * @throws {JsonRpcResponseError} When the response is malformed (version, id, exclusivity, size).
    */
-  public async request(method: string, params: unknown, headers = new Headers()): Promise<unknown> {
+  public async request(
+    method: string,
+    params: unknown,
+    headers = new Headers(),
+    options?: IRequestOptions,
+  ): Promise<unknown> {
     headers.set('Content-Type', 'application/json');
 
     const id = uuid();
@@ -86,6 +93,7 @@ export class JsonRpcHttpTransport {
       headers,
       method: 'POST',
       redirect: 'error',
+      signal: options?.signal,
     });
 
     const body = await JsonRpcHttpTransport.readBoundedText(response, this.maxResponseBytes);

--- a/src/util/InclusionProofUtils.ts
+++ b/src/util/InclusionProofUtils.ts
@@ -11,33 +11,147 @@ import {
 } from '../transaction/verification/rule/InclusionProofVerificationRule.js';
 
 /**
- * Thrown by {@link waitInclusionProof} when the polling sleep is aborted
- * (typically because the caller's abort signal fired).
+ * Thrown by {@link waitInclusionProof} when the wait is aborted, whether the
+ * caller's abort signal fires while a poll request is in flight, while its
+ * response is being verified, or while sleeping between polls.
  */
-class SleepError extends Error {
-  public constructor(message: string) {
-    super(message);
+export class SleepError extends Error {
+  public constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'SleepError';
   }
 }
 
+/**
+ * Build the error reported when the caller's abort signal has fired. Nothing
+ * here may throw: it runs inside the `abort` listeners, and an exception there
+ * would skip the `reject` that ends the wait — the very hang this module
+ * guards against.
+ *
+ * @param {AbortSignal} signal Aborted signal.
+ * @returns {SleepError} Error carrying the signal's abort reason.
+ */
+function createAbortError(signal: AbortSignal): SleepError {
+  let reason: Error | undefined;
+  let message = 'Wait was aborted';
+  try {
+    reason = signal.reason as Error | undefined;
+    if (reason != null) {
+      message = reason.toString();
+    }
+  } catch {
+    // A signal whose reason cannot be read or described still has to end the wait.
+  }
+
+  return new SleepError(message, { cause: reason });
+}
+
+/**
+ * Detach an abort listener without letting a hostile or exotic signal break
+ * the wait. The listeners are one-shot, so a refused removal is harmless.
+ *
+ * @param {AbortSignal} signal Signal the listener was attached to.
+ * @param {Function} listener Listener to detach.
+ */
+function removeAbortListener(signal: AbortSignal, listener: () => void): void {
+  try {
+    signal.removeEventListener('abort', listener);
+  } catch {
+    // Cleanup is best effort; failing it must not leave a promise unsettled.
+  }
+}
+
+/**
+ * Stop the wait immediately if the signal has already fired.
+ *
+ * @param {AbortSignal} signal Signal to inspect.
+ * @throws {SleepError} If the signal is aborted.
+ */
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw createAbortError(signal);
+  }
+}
+
+/**
+ * Run one poll bounded by the caller's signal. The poll is handed a fresh
+ * signal of its own so that the abort reaches the transport as a plain
+ * `AbortSignal` — callers may pass any signal-like wrapper — and cancels only
+ * this request. The wait settles as soon as either the poll settles or the
+ * signal fires, so a poll that ignores its signal, or never responds at all,
+ * still cannot outlive the caller's deadline.
+ *
+ * @param {Function} poll Runs one poll with the request's own abort signal.
+ * @param {AbortSignal} signal Signal that ends the wait.
+ * @returns {Promise} Promise settling with the poll, or rejecting on abort.
+ * @throws {SleepError} If the signal fires before the poll settles.
+ */
+function abortable<T>(poll: (signal: AbortSignal) => Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const request = new AbortController();
+
+    function onAbort(): void {
+      // Reject first: the wait must end even if cancelling the request does not.
+      const error = createAbortError(signal);
+      reject(error);
+      request.abort(error.cause);
+    }
+
+    // An already-aborted signal never dispatches `abort` again, so a listener
+    // attached now would never fire: check first, subscribe second.
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    // Both outcomes stay handled, so a poll that rejects after the wait has
+    // already been abandoned is not reported as an unhandled rejection.
+    void poll(request.signal)
+      .then(resolve, reject)
+      .finally(() => removeAbortListener(signal, onAbort));
+  });
+}
+
+/**
+ * Wait for the given delay, unless the signal fires first.
+ *
+ * @param {number} ms Delay in milliseconds.
+ * @param {AbortSignal} signal Signal that ends the wait.
+ * @returns {Promise<void>} Promise resolving once the delay has elapsed.
+ * @throws {SleepError} If the signal is or becomes aborted.
+ */
 function sleep(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(resolve, ms);
-    signal.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(timeout);
-        reject(signal.reason as Error);
-      },
-      { once: true },
-    );
+    // Same lost-abort hazard as above: an `abort` listener registered after the
+    // signal has fired is never called, which would leave the poll loop running
+    // for the lifetime of the process.
+    if (signal.aborted) {
+      reject(createAbortError(signal));
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      removeAbortListener(signal, onAbort);
+      resolve();
+    }, ms);
+
+    function onAbort(): void {
+      clearTimeout(timeout);
+      reject(createAbortError(signal));
+    }
+
+    signal.addEventListener('abort', onAbort, { once: true });
   });
 }
 
 /**
  * Poll the aggregator until a valid inclusion proof for the given transaction
  * is available, or the abort signal fires.
+ *
+ * The returned promise always settles: once the signal has fired the wait
+ * rejects, regardless of whether the deadline was reached while requesting,
+ * while verifying, or while sleeping between polls.
  *
  * @param {StateTransitionClient} client Client used to fetch inclusion proofs.
  * @param {RootTrustBase} trustBase Root trust base used to verify the inclusion certificate.
@@ -46,7 +160,7 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
  * @param {AbortSignal} signal Abort signal that terminates polling. Defaults to a 10s timeout.
  * @param {number} interval Delay between polls in milliseconds. Defaults to 1000.
  * @returns {Promise<InclusionProof>} Verified inclusion proof.
- * @throws {SleepError} If the abort signal fires while sleeping between polls.
+ * @throws {SleepError} If the abort signal fires before a proof is available.
  */
 export async function waitInclusionProof(
   client: StateTransitionClient,
@@ -58,36 +172,44 @@ export async function waitInclusionProof(
 ): Promise<InclusionProof> {
   const stateId = await StateId.fromTransaction(transaction);
   const transactionHash = await transaction.calculateTransactionHash();
-  while (true) {
-    try {
-      const inclusionProof = await client.getInclusionProof(stateId).then((response) => response.inclusionProof);
-      const verificationStatus = await InclusionProofVerificationRule.verify(
-        trustBase,
-        predicateVerifier,
-        inclusionProof,
-        transactionHash,
-        transaction.lockScript,
-        transaction.sourceStateHash,
-      );
 
-      switch (verificationStatus.status) {
-        case InclusionProofVerificationStatus.OK:
-          return inclusionProof;
-        case InclusionProofVerificationStatus.INCLUSION_CERTIFICATE_MISSING:
-          break;
-        default:
-          throw new Error(`Invalid inclusion proof status: ${verificationStatus.status}`);
+  const poll = async (requestSignal: AbortSignal): Promise<InclusionProof | null> => {
+    const { inclusionProof } = await client.getInclusionProof(stateId, { signal: requestSignal });
+    const verificationStatus = await InclusionProofVerificationRule.verify(
+      trustBase,
+      predicateVerifier,
+      inclusionProof,
+      transactionHash,
+      transaction.lockScript,
+      transaction.sourceStateHash,
+    );
+
+    switch (verificationStatus.status) {
+      case InclusionProofVerificationStatus.OK:
+        return inclusionProof;
+      case InclusionProofVerificationStatus.INCLUSION_CERTIFICATE_MISSING:
+        return null;
+      default:
+        throw new Error(`Invalid inclusion proof status: ${verificationStatus.status}`);
+    }
+  };
+
+  while (true) {
+    throwIfAborted(signal);
+
+    try {
+      const inclusionProof = await abortable(poll, signal);
+      if (inclusionProof !== null) {
+        return inclusionProof;
       }
     } catch (err) {
+      // A missing proof is the expected "not certified yet" answer; anything
+      // else — including the {@link SleepError} raised on abort — ends the wait.
       if (!(err instanceof JsonRpcNetworkError && err.status === 404)) {
         throw err;
       }
     }
 
-    try {
-      await sleep(interval, signal);
-    } catch (err) {
-      throw new SleepError(err?.toString() || 'Sleep was aborted');
-    }
+    await sleep(interval, signal);
   }
 }

--- a/tests/e2e/E2EConfig.ts
+++ b/tests/e2e/E2EConfig.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+
+import defaultTrustBaseJson from './trust-base.json' with { type: 'json' };
+import { AggregatorClient } from '../../src/api/AggregatorClient.js';
+import { RootTrustBase } from '../../src/api/bft/RootTrustBase.js';
+import { IAggregatorClient } from '../../src/api/IAggregatorClient.js';
+import { StateTransitionClient } from '../../src/StateTransitionClient.js';
+
+/**
+ * Aggregator endpoint under test. Defaults to a local aggregator; point
+ * `AGGREGATOR_URL` at a real network (together with `TRUST_BASE_PATH` and,
+ * when the endpoint requires one, `AGGREGATOR_API_KEY`) to run against it.
+ */
+export const AGGREGATOR_URL = process.env.AGGREGATOR_URL ?? 'http://localhost:3000';
+
+/**
+ * Build the client and trust base the e2e suite runs against.
+ *
+ * @returns {object} Aggregator client, state transition client and trust base for the configured endpoint.
+ */
+export function createE2EContext(): {
+  aggregatorClient: IAggregatorClient;
+  client: StateTransitionClient;
+  trustBase: RootTrustBase;
+} {
+  const aggregatorClient = new AggregatorClient(AGGREGATOR_URL, process.env.AGGREGATOR_API_KEY ?? null);
+  const trustBasePath = process.env.TRUST_BASE_PATH ?? null;
+
+  return {
+    aggregatorClient,
+    client: new StateTransitionClient(aggregatorClient),
+    trustBase: RootTrustBase.fromJSON(
+      trustBasePath ? JSON.parse(readFileSync(trustBasePath, 'utf-8')) : defaultTrustBaseJson,
+    ),
+  };
+}

--- a/tests/e2e/E2ETransitionFlowTest.ts
+++ b/tests/e2e/E2ETransitionFlowTest.ts
@@ -1,13 +1,8 @@
-import trustBaseJson from './trust-base.json' with { type: 'json' };
-import { AggregatorClient } from '../../src/api/AggregatorClient.js';
-import { RootTrustBase } from '../../src/api/bft/RootTrustBase.js';
-import { StateTransitionClient } from '../../src/StateTransitionClient.js';
+import { createE2EContext } from './E2EConfig.js';
 import { transitionFlowTest } from '../utils/TransitionFlow.js';
 
 describe('E2E TransitionFlow', () => {
-  const aggregatorClient = new AggregatorClient('http://localhost:3000');
-  const client = new StateTransitionClient(aggregatorClient);
-  const trustBase = RootTrustBase.fromJSON(trustBaseJson);
+  const { client, trustBase } = createE2EContext();
 
   transitionFlowTest(client, trustBase);
 });

--- a/tests/e2e/InclusionProofDeadlineTest.ts
+++ b/tests/e2e/InclusionProofDeadlineTest.ts
@@ -1,0 +1,100 @@
+import { createE2EContext } from './E2EConfig.js';
+import { CertificationData } from '../../src/api/CertificationData.js';
+import { CertificationResponse } from '../../src/api/CertificationResponse.js';
+import { IAggregatorClient } from '../../src/api/IAggregatorClient.js';
+import { InclusionProofResponse } from '../../src/api/InclusionProofResponse.js';
+import { IRequestOptions } from '../../src/api/IRequestOptions.js';
+import { StateId } from '../../src/api/StateId.js';
+import { SigningService } from '../../src/crypto/secp256k1/SigningService.js';
+import { SignaturePredicate } from '../../src/predicate/builtin/SignaturePredicate.js';
+import { PredicateVerifierService } from '../../src/predicate/verification/PredicateVerifierService.js';
+import { StateTransitionClient } from '../../src/StateTransitionClient.js';
+import { MintTransaction } from '../../src/transaction/MintTransaction.js';
+import { TokenSalt } from '../../src/transaction/TokenSalt.js';
+import { TokenType } from '../../src/transaction/TokenType.js';
+import { waitInclusionProof } from '../../src/util/InclusionProofUtils.js';
+
+/** How long a wait may run past its own deadline before it counts as unbounded. */
+const UNBOUNDED_AFTER_MS = 20000;
+
+/**
+ * Aggregator client that fires the caller's deadline while a real request to
+ * the aggregator is still in flight — the window in which the abort used to be
+ * lost, leaving the poll loop running for the lifetime of the process.
+ */
+class DeadlineDuringRequestClient implements IAggregatorClient {
+  public constructor(
+    private readonly delegate: IAggregatorClient,
+    private readonly controller: AbortController,
+    private readonly delayMs: number,
+  ) {}
+
+  public getInclusionProof(stateId: StateId, options?: IRequestOptions): Promise<InclusionProofResponse> {
+    const response = this.delegate.getInclusionProof(stateId, options);
+    const abort = (): void => this.controller.abort(new Error('deadline reached'));
+    if (this.delayMs === 0) {
+      abort();
+    } else {
+      setTimeout(abort, this.delayMs).unref();
+    }
+
+    return response;
+  }
+
+  public submitCertificationRequest(certificationData: CertificationData): Promise<CertificationResponse> {
+    return this.delegate.submitCertificationRequest(certificationData);
+  }
+}
+
+describe('E2E waitInclusionProof deadline', () => {
+  const { aggregatorClient, trustBase } = createE2EContext();
+  const predicateVerifier = PredicateVerifierService.create();
+
+  let transaction: MintTransaction;
+
+  beforeAll(async () => {
+    // Never submitted, so the aggregator never certifies it and every wait for
+    // it can only end at its deadline.
+    transaction = await MintTransaction.create(
+      trustBase.networkId,
+      SignaturePredicate.create(SigningService.generate().publicKey),
+      null,
+      TokenType.generate(),
+      TokenSalt.generate(),
+      null,
+    );
+  });
+
+  const outcomeOf = async (client: StateTransitionClient, signal: AbortSignal, interval: number): Promise<string> => {
+    let guard: ReturnType<typeof setTimeout> | undefined;
+    const outcome = await Promise.race([
+      waitInclusionProof(client, trustBase, predicateVerifier, transaction, signal, interval).then(
+        () => 'resolved',
+        (err: unknown) => (err instanceof Error ? err.name : String(err)),
+      ),
+      new Promise<string>((resolve) => {
+        guard = setTimeout(() => resolve('unbounded'), UNBOUNDED_AFTER_MS);
+      }),
+    ]);
+    clearTimeout(guard);
+
+    return outcome;
+  };
+
+  it.each([0, 1, 5, 20])(
+    'should stop polling when the deadline fires %sms into a request',
+    async (delayMs) => {
+      const controller = new AbortController();
+      const client = new StateTransitionClient(new DeadlineDuringRequestClient(aggregatorClient, controller, delayMs));
+
+      await expect(outcomeOf(client, controller.signal, 1000)).resolves.toBe('SleepError');
+    },
+    30000,
+  );
+
+  it('should stop polling when the deadline fires between polls', async () => {
+    const { client } = createE2EContext();
+
+    await expect(outcomeOf(client, AbortSignal.timeout(500), 5000)).resolves.toBe('SleepError');
+  }, 30000);
+});

--- a/tests/e2e/ShardAggregatorClient.ts
+++ b/tests/e2e/ShardAggregatorClient.ts
@@ -4,6 +4,7 @@ import { CertificationRequest } from '../../src/api/CertificationRequest.js';
 import { CertificationResponse } from '../../src/api/CertificationResponse.js';
 import { IAggregatorClient } from '../../src/api/IAggregatorClient.js';
 import { InclusionProofResponse } from '../../src/api/InclusionProofResponse.js';
+import { IRequestOptions } from '../../src/api/IRequestOptions.js';
 import { JsonRpcHttpTransport } from '../../src/api/json-rpc/JsonRpcHttpTransport.js';
 import { StateId } from '../../src/api/StateId.js';
 import { HexConverter } from '../../src/util/HexConverter.js';
@@ -23,11 +24,11 @@ export class ShardAggregatorClient implements IAggregatorClient {
       .map(([shardId, url]) => [shardId, new JsonRpcHttpTransport(url)]);
   }
 
-  public async getInclusionProof(stateId: StateId): Promise<InclusionProofResponse> {
+  public async getInclusionProof(stateId: StateId, options?: IRequestOptions): Promise<InclusionProofResponse> {
     const transport = this.getTransport(stateId);
     const data = { stateId: HexConverter.encode(stateId.data) };
     return InclusionProofResponse.fromCBOR(
-      HexConverter.decode((await transport.request('get_inclusion_proof.v2', data)) as string),
+      HexConverter.decode((await transport.request('get_inclusion_proof.v2', data, new Headers(), options)) as string),
     );
   }
 

--- a/tests/unit/api/AggregatorClientTest.ts
+++ b/tests/unit/api/AggregatorClientTest.ts
@@ -1,4 +1,6 @@
 import { AggregatorClient } from '../../../src/api/AggregatorClient.js';
+import { StateId } from '../../../src/api/StateId.js';
+import { CborSerializer } from '../../../src/serialization/cbor/CborSerializer.js';
 
 describe('AggregatorClient', () => {
   it('should reject an API key over plaintext HTTP', () => {
@@ -15,6 +17,20 @@ describe('AggregatorClient', () => {
 
   it('should allow an API key over plaintext HTTP when insecure transport is enabled', () => {
     expect(() => new AggregatorClient('http://localhost:3000', 'secret-key', true)).not.toThrow();
+  });
+
+  it('should forward the abort signal of an inclusion proof request to fetch', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue(new Response('', { status: 404 }));
+    try {
+      const client = new AggregatorClient('https://example.com');
+      const stateId = StateId.fromCBOR(CborSerializer.encodeByteString(new Uint8Array(32)));
+      const controller = new AbortController();
+
+      await expect(client.getInclusionProof(stateId, { signal: controller.signal })).rejects.toThrow();
+      expect(fetchMock.mock.calls[0][1]?.signal).toBe(controller.signal);
+    } finally {
+      fetchMock.mockRestore();
+    }
   });
 
   it('should not expose the API key on inspection', () => {

--- a/tests/unit/api/json-rpc/JsonRpcHttpTransportTest.ts
+++ b/tests/unit/api/json-rpc/JsonRpcHttpTransportTest.ts
@@ -49,6 +49,28 @@ describe('JsonRpcHttpTransport', () => {
     await expect(transport.request('m', {})).rejects.toThrow('boom');
   });
 
+  it('should forward the abort signal to fetch', async () => {
+    respondWith((id) => ({ id, jsonrpc: '2.0', result: 'ok' }));
+    const controller = new AbortController();
+
+    await expect(transport.request('m', {}, new Headers(), { signal: controller.signal })).resolves.toBe('ok');
+    expect(fetchMock.mock.calls[0][1]?.signal).toBe(controller.signal);
+  });
+
+  it('should reject once the request is aborted', async () => {
+    fetchMock.mockImplementation((_input, init) => {
+      const { signal } = init ?? {};
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(signal.reason as Error), { once: true });
+      });
+    });
+    const controller = new AbortController();
+    const request = transport.request('m', {}, new Headers(), { signal: controller.signal });
+    controller.abort(new Error('aborted by caller'));
+
+    await expect(request).rejects.toThrow('aborted by caller');
+  });
+
   it('should decode a multi-byte UTF-8 character split across stream chunks', async () => {
     fetchMock.mockImplementation((_input, init) => {
       const id = (JSON.parse((init?.body as string) ?? '{}') as { id: unknown }).id;

--- a/tests/unit/util/InclusionProofUtilsTest.ts
+++ b/tests/unit/util/InclusionProofUtilsTest.ts
@@ -1,0 +1,307 @@
+import { getEventListeners } from 'node:events';
+
+import { CertificationResponse } from '../../../src/api/CertificationResponse.js';
+import { IAggregatorClient } from '../../../src/api/IAggregatorClient.js';
+import { InclusionProof } from '../../../src/api/InclusionProof.js';
+import { InclusionProofResponse } from '../../../src/api/InclusionProofResponse.js';
+import { IRequestOptions } from '../../../src/api/IRequestOptions.js';
+import { JsonRpcNetworkError } from '../../../src/api/json-rpc/JsonRpcNetworkError.js';
+import { NetworkId } from '../../../src/api/NetworkId.js';
+import { StateId } from '../../../src/api/StateId.js';
+import { DataHash } from '../../../src/crypto/hash/DataHash.js';
+import { HashAlgorithm } from '../../../src/crypto/hash/HashAlgorithm.js';
+import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
+import { SignaturePredicate } from '../../../src/predicate/builtin/SignaturePredicate.js';
+import { PredicateVerifierService } from '../../../src/predicate/verification/PredicateVerifierService.js';
+import { StateTransitionClient } from '../../../src/StateTransitionClient.js';
+import { MintTransaction } from '../../../src/transaction/MintTransaction.js';
+import { TokenSalt } from '../../../src/transaction/TokenSalt.js';
+import { TokenType } from '../../../src/transaction/TokenType.js';
+import { SleepError, waitInclusionProof } from '../../../src/util/InclusionProofUtils.js';
+import { createRootTrustBase } from '../../utils/RootTrustBaseFixture.js';
+import { createUnicityCertificate } from '../../utils/UnicityCertificateFixture.js';
+
+interface IDeferred<T> {
+  readonly promise: Promise<T>;
+  reject(reason: unknown): void;
+  resolve(value: T): void;
+}
+
+function createDeferred<T>(): IDeferred<T> {
+  let reject!: (reason: unknown) => void;
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res, rej) => {
+    reject = rej;
+    resolve = res;
+  });
+
+  return { promise, reject, resolve };
+}
+
+/**
+ * Aggregator client whose inclusion-proof responses are fully driven by the test.
+ */
+class StubAggregatorClient implements IAggregatorClient {
+  public readonly requests: (IRequestOptions | undefined)[] = [];
+
+  public constructor(private readonly handler: (call: number) => Promise<InclusionProofResponse>) {}
+
+  public get callCount(): number {
+    return this.requests.length;
+  }
+
+  public getInclusionProof(_stateId: StateId, options?: IRequestOptions): Promise<InclusionProofResponse> {
+    this.requests.push(options);
+    return this.handler(this.requests.length);
+  }
+
+  public submitCertificationRequest(): Promise<CertificationResponse> {
+    throw new Error('Certification requests are not part of these tests.');
+  }
+}
+
+describe('waitInclusionProof', () => {
+  const signingService = SigningService.generate();
+  const trustBase = createRootTrustBase(signingService.publicKey);
+  const predicateVerifier = PredicateVerifierService.create();
+
+  let transaction: MintTransaction;
+  let pendingProof: InclusionProof;
+
+  beforeAll(async () => {
+    transaction = await MintTransaction.create(
+      NetworkId.LOCAL,
+      SignaturePredicate.create(signingService.publicKey),
+      null,
+      TokenType.generate(),
+      TokenSalt.generate(),
+      null,
+    );
+    // A proof without an inclusion certificate is what the aggregator returns
+    // for a state it has not certified yet, i.e. "keep polling".
+    pendingProof = new InclusionProof(
+      null,
+      null,
+      await createUnicityCertificate(new DataHash(HashAlgorithm.SHA256, new Uint8Array(32)), signingService),
+    );
+  });
+
+  const wait = (aggregatorClient: IAggregatorClient, signal: AbortSignal, interval = 10): Promise<InclusionProof> =>
+    waitInclusionProof(
+      new StateTransitionClient(aggregatorClient),
+      trustBase,
+      predicateVerifier,
+      transaction,
+      signal,
+      interval,
+    );
+
+  const notFound = (): Promise<InclusionProofResponse> =>
+    Promise.reject(new JsonRpcNetworkError(404, 'Inclusion proof not found'));
+
+  it('should reject when the deadline fires while a request is in flight', async () => {
+    const started = createDeferred<void>();
+    const response = createDeferred<InclusionProofResponse>();
+    const controller = new AbortController();
+    const client = new StubAggregatorClient(() => {
+      started.resolve();
+      return response.promise;
+    });
+
+    const result = wait(client, controller.signal);
+    await started.promise;
+    controller.abort(new Error('deadline reached'));
+
+    await expect(result).rejects.toThrow(SleepError);
+    expect(client.callCount).toBe(1);
+    response.reject(new JsonRpcNetworkError(404, 'Inclusion proof not found'));
+  });
+
+  it('should reject when the signal fires before the abort listener could be attached', async () => {
+    // The reported hang: the deadline elapses while the request is in flight, so
+    // the loop only learns about it after the response has already been handled.
+    // An `abort` listener registered at that point is never called.
+    const controller = new AbortController();
+    const client = new StubAggregatorClient(() => {
+      controller.abort(new Error('deadline reached'));
+      return notFound();
+    });
+
+    await expect(wait(client, controller.signal)).rejects.toThrow(SleepError);
+    expect(client.callCount).toBe(1);
+  });
+
+  it('should reject when the signal fires while sleeping between polls', async () => {
+    const client = new StubAggregatorClient(() => notFound());
+
+    await expect(wait(client, AbortSignal.timeout(50), 1000)).rejects.toThrow(SleepError);
+    expect(client.callCount).toBe(1);
+  });
+
+  it('should reject without issuing a request when the signal is already aborted', async () => {
+    const client = new StubAggregatorClient(() => notFound());
+    const controller = new AbortController();
+    controller.abort(new Error('already gone'));
+
+    await expect(wait(client, controller.signal)).rejects.toThrow(SleepError);
+    expect(client.callCount).toBe(0);
+  });
+
+  it('should reject when a request never settles and ignores the signal', async () => {
+    const started = createDeferred<void>();
+    const controller = new AbortController();
+    const client = new StubAggregatorClient(() => {
+      started.resolve();
+      return new Promise<InclusionProofResponse>(() => undefined);
+    });
+
+    const result = wait(client, controller.signal);
+    await started.promise;
+    controller.abort(new Error('deadline reached'));
+
+    await expect(result).rejects.toThrow(SleepError);
+  });
+
+  it('should still end the wait when the abort reason cannot be described', async () => {
+    // A reason without Object.prototype throws on any attempt to stringify it.
+    // Building the error must not be what prevents the wait from ending.
+    const controller = new AbortController();
+    const client = new StubAggregatorClient(() => {
+      controller.abort(Object.create(null));
+      return notFound();
+    });
+
+    await expect(wait(client, controller.signal)).rejects.toThrow(SleepError);
+  });
+
+  it('should still end the wait when the signal refuses listener removal', async () => {
+    const controller = new AbortController();
+    const hostile = new Proxy(controller.signal, {
+      get(target: AbortSignal, property: string | symbol): unknown {
+        if (property === 'removeEventListener') {
+          return (): never => {
+            throw new Error('removal refused');
+          };
+        }
+        const value: unknown = Reflect.get(target, property, target);
+        return typeof value === 'function' ? (value as (...args: unknown[]) => unknown).bind(target) : value;
+      },
+    });
+    const client = new StubAggregatorClient((call) => {
+      if (call >= 2) {
+        controller.abort(new Error('deadline reached'));
+      }
+      return notFound();
+    });
+
+    await expect(wait(client, hostile, 1)).rejects.toThrow(SleepError);
+    expect(client.callCount).toBe(2);
+  });
+
+  it('should report the abort reason', async () => {
+    const reason = new Error('deadline reached');
+    const client = new StubAggregatorClient(() => notFound());
+    const controller = new AbortController();
+    controller.abort(reason);
+
+    await expect(wait(client, controller.signal)).rejects.toThrow('Error: deadline reached');
+    await expect(wait(client, controller.signal)).rejects.toMatchObject({ cause: reason, name: 'SleepError' });
+  });
+
+  it('should hand the aggregator client a plain abort signal that cancels the request', async () => {
+    const controller = new AbortController();
+    const client = new StubAggregatorClient(() => {
+      controller.abort(new Error('deadline reached'));
+      return notFound();
+    });
+
+    await expect(wait(client, controller.signal)).rejects.toThrow(SleepError);
+    const requestSignal = client.requests[0]?.signal;
+    // Not the caller's own signal: callers may pass a wrapper, and only a plain
+    // AbortSignal can be handed to `fetch`.
+    expect(requestSignal).toBeInstanceOf(AbortSignal);
+    expect(requestSignal).not.toBe(controller.signal);
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  it('should not cancel the next request because an earlier one was aborted', async () => {
+    const client = new StubAggregatorClient(() => notFound());
+
+    await expect(wait(client, AbortSignal.timeout(60), 1)).rejects.toThrow(SleepError);
+    expect(client.callCount).toBeGreaterThan(1);
+    expect(client.requests.slice(0, -1).every((options) => options?.signal?.aborted === false)).toBe(true);
+  });
+
+  it('should accept a signal wrapper that only exposes the AbortSignal surface', async () => {
+    const controller = new AbortController();
+    // Mirrors the defensive wrapper shipped downstream, which re-delivers
+    // `abort` to listeners attached after the signal has already fired.
+    const wrapped = new Proxy(controller.signal, {
+      get(target: AbortSignal, property: string | symbol): unknown {
+        if (property === 'addEventListener') {
+          return (type: string, listener: EventListener, options?: AddEventListenerOptions): void => {
+            if (type === 'abort' && target.aborted) {
+              queueMicrotask(() => listener.call(target, new Event('abort')));
+              return;
+            }
+            target.addEventListener(type, listener, options);
+          };
+        }
+        const value: unknown = Reflect.get(target, property, target);
+        return typeof value === 'function' ? (value as (...args: unknown[]) => unknown).bind(target) : value;
+      },
+    });
+    const client = new StubAggregatorClient(() => {
+      controller.abort(new Error('deadline reached'));
+      return notFound();
+    });
+
+    await expect(wait(client, wrapped)).rejects.toThrow(SleepError);
+    expect(client.requests[0]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('should keep polling while the inclusion certificate is missing', async () => {
+    const controller = new AbortController();
+    const client = new StubAggregatorClient((call) => {
+      if (call >= 3) {
+        controller.abort(new Error('deadline reached'));
+      }
+      return Promise.resolve(new InclusionProofResponse(1n, pendingProof));
+    });
+
+    await expect(wait(client, controller.signal, 1)).rejects.toThrow(SleepError);
+    expect(client.callCount).toBe(3);
+  });
+
+  it('should not accumulate abort listeners across polls', async () => {
+    const controller = new AbortController();
+    const listeners: number[] = [];
+    const client = new StubAggregatorClient((call) => {
+      listeners.push(getEventListeners(controller.signal, 'abort').length);
+      if (call >= 5) {
+        controller.abort(new Error('deadline reached'));
+      }
+      return notFound();
+    });
+
+    await expect(wait(client, controller.signal, 1)).rejects.toThrow(SleepError);
+    expect(Math.max(...listeners)).toBeLessThanOrEqual(1);
+  });
+
+  it('should propagate a non-404 error instead of retrying', async () => {
+    const client = new StubAggregatorClient(() => Promise.reject(new JsonRpcNetworkError(500, 'Server error')));
+
+    await expect(wait(client, AbortSignal.timeout(1000))).rejects.toThrow(JsonRpcNetworkError);
+    expect(client.callCount).toBe(1);
+  });
+
+  it('should report the abort rather than the outcome of a poll it no longer waits for', async () => {
+    const controller = new AbortController();
+    const client = new StubAggregatorClient(() => {
+      controller.abort(new Error('deadline reached'));
+      return Promise.reject(new JsonRpcNetworkError(500, 'Server error'));
+    });
+
+    await expect(wait(client, controller.signal)).rejects.toThrow(SleepError);
+  });
+});


### PR DESCRIPTION
Fixes #140.

## Cause

`sleep()` attached its `abort` listener without first checking `signal.aborted`. An `AbortSignal` dispatches `abort` exactly once, so when the deadline fell during an in-flight request the abort was lost: every later `sleep()` resolved on its own timer, `while (true)` kept polling for the lifetime of the process, and the returned promise never settled.

## Changes

`src/util/InclusionProofUtils.ts`

- **`sleep()` pre-checks `signal.aborted`** — the minimal fix from the issue — and detaches its listener when the timer fires, instead of leaving one behind on the caller's signal per poll.
- **Each iteration checks the signal before issuing a request**, and runs the poll inside `abortable()`, which races it against the signal. The wait is bounded even when the client ignores its signal or never responds at all, so the contract holds regardless of the `IAggregatorClient` implementation.
- **`abortable()` gives each poll a fresh `AbortController`** rather than passing the caller's signal down. Callers may pass a signal-like wrapper — sphere-sdk's workaround passes a `Proxy` — and a Proxy of a platform object fails WebIDL conversion when it reaches `fetch` in a browser. The transport now always receives a plain `AbortSignal`, and cancelling one poll cannot affect anything else.
- **Nothing on the abort path can throw.** An unreadable abort reason or a signal that refuses listener removal must not be the thing that prevents the wait from ending — that is the same failure class as the bug itself.
- **`SleepError` is exported** and carries the abort reason as `cause`. Its `name` and message are unchanged, so `err.name === 'SleepError'` checks keep working.

Signal threading, so an abandoned request is released rather than left to run: an optional `IRequestOptions` `{ signal }` passes from `StateTransitionClient` through `IAggregatorClient` and `AggregatorClient` into `JsonRpcHttpTransport`'s `fetch`. Optional throughout — existing `IAggregatorClient` implementations keep compiling (`TestAggregatorClient` is untouched and passes).

Also: the e2e suite reads `AGGREGATOR_URL` / `TRUST_BASE_PATH` / `AGGREGATOR_API_KEY` so it can be pointed at a real network, and README's dead `gateway-test.unicity.network` (its TLS certificate is issued for `goggregator-test.unicity.network`) is replaced with the endpoint that actually serves.

## Verification

|  | pre-fix | fixed |
| --- | --- | --- |
| New unit tests | 11 of 13 fail, 9 by hanging past the timeout | all pass |
| e2e deadline tests, real testnet | 3 of 5 unbounded; jest cannot exit | all pass, clean exit |
| The issue's own repro, 30 trials | 13 hangs, process never exits | **30/30 `SleepError`, 0 hangs, exits on its own** |

- `npm run test:ci`: 136 tests pass. `build:check` and `lint` clean.
- **Real testnet** (`https://gateway.testnet2.unicity.network`): mint + two transfers with real certification and verification, plus the five deadline tests — 6/6.
- Probed against the built package under `--unhandled-rejections=strict`: 20 concurrent waits sharing one signal all reject and drop back to zero listeners; `interval: 0`; a synchronously throwing client (its own error propagates rather than being masked); a reused already-aborted signal; a client that hangs and ignores its signal — every case terminates and nothing leaks.

## Notes for consumers

- **The deadline is now genuinely enforced.** A wait that used to run past its timeout by accident, because the abort was lost, now rejects with `SleepError`. Timeouts sized against that behaviour may need raising.
- **When the deadline wins the race, the poll's own outcome is dropped** — including a proof that had just verified OK, or a non-404 error from that same poll. The abort is reported instead. Errors that arrive before the abort still propagate unchanged.
- sphere-sdk's `lateDeliveringSignal` workaround (unicity-sphere/sphere-sdk#740) can be retired once this ships; it stays correct in the meantime.

Not addressed here, as flagged in the issue: a non-404 response (429, 5xx) still ends the whole wait on first occurrence. Worth its own issue — a shared-key 429 defeating an otherwise recoverable flow is easy to hit in practice.
