### PR TITLE
perf: memoise seal verification and drop the redundant EC op in verifyWithPublicKey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unicitylabs/state-transition-sdk",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unicitylabs/state-transition-sdk",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "@noble/curves": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicitylabs/state-transition-sdk",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Generic State Transition Flow engine for value-carrier agents",
   "type": "module",
   "exports": {

--- a/src/api/bft/verification/UnicityCertificateVerifier.ts
+++ b/src/api/bft/verification/UnicityCertificateVerifier.ts
@@ -1,12 +1,14 @@
 import { UnicitySealHashMatchesWithRootHashRule } from './rule/UnicitySealHashMatchesWithRootHashRule.js';
 import { UnicitySealQuorumSignaturesVerificationRule } from './rule/UnicitySealQuorumSignaturesVerificationRule.js';
+import { ISignatureVerifier } from '../../../crypto/ISignatureVerifier.js';
+import { Signature } from '../../../crypto/secp256k1/Signature.js';
 import { VerificationResult } from '../../../verification/VerificationResult.js';
 import { VerificationStatus } from '../../../verification/VerificationStatus.js';
 import { InclusionProof } from '../../InclusionProof.js';
 import { RootTrustBase } from '../RootTrustBase.js';
 
 /**
- * Result of a {@link UnicityCertificateVerification} run.
+ * Result of a {@link UnicityCertificateVerifier} run.
  */
 class UnicityCertificateVerificationResult extends VerificationResult<VerificationStatus> {
   private constructor(status: VerificationStatus, results: VerificationResult<unknown>[]) {
@@ -36,8 +38,17 @@ class UnicityCertificateVerificationResult extends VerificationResult<Verificati
 
 /**
  * Unicity certificate verification.
+ *
+ * Owns the {@link ISignatureVerifier} used for the seal's quorum signatures, so
+ * callers pass this domain-level verifier around rather than a bare signature
+ * verifier that says nothing about what it verifies.
  */
-export class UnicityCertificateVerification {
+export class UnicityCertificateVerifier {
+  /**
+   * @param {ISignatureVerifier<Signature>} signatureVerifier Verifier for root-node signatures.
+   */
+  public constructor(private readonly signatureVerifier: ISignatureVerifier<Signature>) {}
+
   /**
    * Verify the unicity certificate in an inclusion proof against the trust base.
    *
@@ -45,7 +56,7 @@ export class UnicityCertificateVerification {
    * @param {InclusionProof} inclusionProof Inclusion proof carrying the unicity certificate.
    * @returns {Promise<UnicityCertificateVerificationResult>} Verification outcome.
    */
-  public static async verify(
+  public async verify(
     trustBase: RootTrustBase,
     inclusionProof: InclusionProof,
   ): Promise<UnicityCertificateVerificationResult> {
@@ -65,6 +76,7 @@ export class UnicityCertificateVerification {
 
     result = await UnicitySealQuorumSignaturesVerificationRule.verify(
       trustBase,
+      this.signatureVerifier,
       inclusionProof.unicityCertificate.unicitySeal,
     );
     results.push(result);

--- a/src/api/bft/verification/UnicityCertificateVerifier.ts
+++ b/src/api/bft/verification/UnicityCertificateVerifier.ts
@@ -1,7 +1,5 @@
 import { UnicitySealHashMatchesWithRootHashRule } from './rule/UnicitySealHashMatchesWithRootHashRule.js';
 import { UnicitySealQuorumSignaturesVerificationRule } from './rule/UnicitySealQuorumSignaturesVerificationRule.js';
-import { ISignatureVerifier } from '../../../crypto/ISignatureVerifier.js';
-import { Signature } from '../../../crypto/secp256k1/Signature.js';
 import { VerificationResult } from '../../../verification/VerificationResult.js';
 import { VerificationStatus } from '../../../verification/VerificationStatus.js';
 import { InclusionProof } from '../../InclusionProof.js';
@@ -39,15 +37,24 @@ class UnicityCertificateVerificationResult extends VerificationResult<Verificati
 /**
  * Unicity certificate verification.
  *
- * Owns the {@link ISignatureVerifier} used for the seal's quorum signatures, so
- * callers pass this domain-level verifier around rather than a bare signature
- * verifier that says nothing about what it verifies.
+ * Composed from the quorum-signature rule, which carries the signature verifier
+ * and any seal memo, so callers pass this domain-level verifier around rather
+ * than a bare signature verifier that says nothing about what it verifies:
+ *
+ * ```ts
+ * new UnicityCertificateVerifier(
+ *   new UnicitySealQuorumSignaturesVerificationRule(
+ *     new Secp256k1SignatureVerifier(),
+ *     new VerifiedSealCache(256), // omit to verify every seal afresh
+ *   ),
+ * );
+ * ```
  */
 export class UnicityCertificateVerifier {
   /**
-   * @param {ISignatureVerifier<Signature>} signatureVerifier Verifier for root-node signatures.
+   * @param {UnicitySealQuorumSignaturesVerificationRule} quorumSignaturesRule Seal quorum-signature rule.
    */
-  public constructor(private readonly signatureVerifier: ISignatureVerifier<Signature>) {}
+  public constructor(private readonly quorumSignaturesRule: UnicitySealQuorumSignaturesVerificationRule) {}
 
   /**
    * Verify the unicity certificate in an inclusion proof against the trust base.
@@ -74,11 +81,7 @@ export class UnicityCertificateVerifier {
       return UnicityCertificateVerificationResult.fail(results);
     }
 
-    result = await UnicitySealQuorumSignaturesVerificationRule.verify(
-      trustBase,
-      this.signatureVerifier,
-      inclusionProof.unicityCertificate.unicitySeal,
-    );
+    result = await this.quorumSignaturesRule.verify(trustBase, inclusionProof.unicityCertificate.unicitySeal);
     results.push(result);
     if (result.status !== VerificationStatus.OK) {
       return UnicityCertificateVerificationResult.fail(results);

--- a/src/api/bft/verification/VerifiedSealCache.ts
+++ b/src/api/bft/verification/VerifiedSealCache.ts
@@ -1,0 +1,60 @@
+import { VerificationResult } from '../../../verification/VerificationResult.js';
+import { VerificationStatus } from '../../../verification/VerificationStatus.js';
+
+/**
+ * Bounded memo of seals that have already been verified.
+ *
+ * Every leaf certified in one aggregator round shares a seal, so a batch of
+ * inclusion proofs re-verifies the same few seals — measured on testnet2,
+ * twenty proofs shared three seals. Caching that pure result removes most of
+ * the signature work from proof verification.
+ *
+ * The cache is supplied to {@link UnicitySealQuorumSignaturesVerificationRule}
+ * by the caller rather than held statically, so its lifetime and size are the
+ * application's to choose, and a rule constructed without one simply does not
+ * memoise.
+ *
+ * Keys must commit to everything the verdict depends on — the rule builds them;
+ * see its documentation for why the seal's signature-excluding hash is not
+ * enough on its own.
+ */
+export class VerifiedSealCache {
+  private readonly entries = new Map<string, VerificationResult<VerificationStatus>>();
+
+  /**
+   * @param {number} maxEntries Upper bound on retained entries; the oldest is evicted first.
+   * @throws {Error} If `maxEntries` is not a positive integer.
+   */
+  public constructor(private readonly maxEntries: number) {
+    if (!Number.isInteger(maxEntries) || maxEntries <= 0) {
+      throw new Error('VerifiedSealCache maxEntries must be a positive integer');
+    }
+  }
+
+  /**
+   * @param {string} key Cache key.
+   * @returns {VerificationResult<VerificationStatus>|null} Memoised outcome, or null on a miss.
+   */
+  public get(key: string): VerificationResult<VerificationStatus> | null {
+    return this.entries.get(key) ?? null;
+  }
+
+  /**
+   * Store an outcome, evicting the oldest entry once full (`Map` iterates in
+   * insertion order).
+   *
+   * @param {string} key Cache key.
+   * @param {VerificationResult<VerificationStatus>} result Outcome to memoise.
+   * @returns {void}
+   */
+  public set(key: string, result: VerificationResult<VerificationStatus>): void {
+    if (this.entries.size >= this.maxEntries) {
+      const oldest = this.entries.keys().next();
+      if (!oldest.done) {
+        this.entries.delete(oldest.value);
+      }
+    }
+
+    this.entries.set(key, result);
+  }
+}

--- a/src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.ts
+++ b/src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.ts
@@ -1,8 +1,8 @@
 import { DataHash } from '../../../../crypto/hash/DataHash.js';
 import { DataHasher } from '../../../../crypto/hash/DataHasher.js';
 import { HashAlgorithm } from '../../../../crypto/hash/HashAlgorithm.js';
+import { ISignatureVerifier } from '../../../../crypto/ISignatureVerifier.js';
 import { Signature } from '../../../../crypto/secp256k1/Signature.js';
-import { SigningService } from '../../../../crypto/secp256k1/SigningService.js';
 import { HexConverter } from '../../../../util/HexConverter.js';
 import { VerificationResult } from '../../../../verification/VerificationResult.js';
 import { VerificationStatus } from '../../../../verification/VerificationStatus.js';
@@ -23,26 +23,31 @@ export class UnicitySealQuorumSignaturesVerificationRule {
   private static readonly MAX_CACHED_SEALS = 256;
 
   /**
-   * Seals that have already reached quorum, keyed by trust base instance and
-   * then by the hash of the seal's **complete** encoding.
+   * Seals that have already reached quorum, keyed by signature verifier and
+   * then by the hashes of the trust base and of the seal's complete encoding.
    *
-   * Two subtleties make this sound:
+   * Every part of that key is load-bearing:
    *
-   * 1. The key covers the signatures. {@link UnicitySeal.calculateHash} hashes
-   *    the seal *without* them — it is the digest the root nodes sign — so
-   *    keying on it would let a seal's valid signatures be swapped for garbage
-   *    and still hit a cached OK. The key here is over `toCBOR()`, which
-   *    encodes the signatures too, so a cache hit means byte-identical input.
-   * 2. The trust base is part of the key by instance identity (a `WeakMap`),
-   *    since the outcome depends on its root nodes and quorum threshold.
-   *    `RootTrustBase` fields are readonly, so an instance cannot change
-   *    underneath the cache; a different instance simply misses.
+   * 1. The seal key covers the signatures. {@link UnicitySeal.calculateHash}
+   *    hashes the seal *without* them — it is the digest the root nodes sign —
+   *    so keying on it would let a seal's valid signatures be swapped for
+   *    garbage and still hit a cached OK. The key here is over `toCBOR()`,
+   *    which encodes the signatures too, so a hit means byte-identical input.
+   * 2. The trust base decides the outcome through its root nodes and quorum
+   *    threshold, so it is keyed by *content*, not by instance identity:
+   *    `RootTrustBase` exposes `_rootNodes` as a `Map`, and `readonly` stops
+   *    only reassignment, so an application that mutates it in place would
+   *    otherwise keep hitting verdicts computed under the old root keys.
+   * 3. The verifier decides the outcome too, and verifiers are pluggable and
+   *    need not agree — one that binds the recovery byte rejects signatures
+   *    that one checking only `(r, s)` accepts. Keying on the verifier instance
+   *    keeps a verdict from leaking across that boundary.
    *
    * Only quorum-reaching outcomes are stored: a failure is the abnormal path,
    * and not caching it keeps a flood of bad seals from evicting good entries.
    */
   private static readonly VERIFIED_SEALS = new WeakMap<
-    RootTrustBase,
+    ISignatureVerifier<Signature>,
     Map<string, VerificationResult<VerificationStatus>>
   >();
 
@@ -54,17 +59,17 @@ export class UnicitySealQuorumSignaturesVerificationRule {
    * verified seal is memoised (see {@link VERIFIED_SEALS}).
    *
    * @param {RootTrustBase} trustBase Root trust base.
+   * @param {ISignatureVerifier<Signature>} signatureVerifier Verifier for the root-node signatures.
    * @param {UnicitySeal} unicitySeal Seal to verify.
    * @returns {Promise<VerificationResult<VerificationStatus>>} Verification outcome.
    */
   public static async verify(
     trustBase: RootTrustBase,
+    signatureVerifier: ISignatureVerifier<Signature>,
     unicitySeal: UnicitySeal,
   ): Promise<VerificationResult<VerificationStatus>> {
-    const cacheKey = HexConverter.encode(
-      (await new DataHasher(HashAlgorithm.SHA256).update(unicitySeal.toCBOR()).digest()).imprint,
-    );
-    const cached = UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.get(trustBase)?.get(cacheKey);
+    const cacheKey = await UnicitySealQuorumSignaturesVerificationRule.cacheKeyFor(trustBase, unicitySeal);
+    const cached = UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.get(signatureVerifier)?.get(cacheKey);
     if (cached) {
       return cached;
     }
@@ -73,7 +78,13 @@ export class UnicitySealQuorumSignaturesVerificationRule {
 
     const results = await Promise.all(
       Array.from(unicitySeal.signatures?.entries() ?? []).map(([nodeId, signature]) =>
-        UnicitySealQuorumSignaturesVerificationRule.verifySignature(trustBase, nodeId, signature, hash),
+        UnicitySealQuorumSignaturesVerificationRule.verifySignature(
+          trustBase,
+          signatureVerifier,
+          nodeId,
+          signature,
+          hash,
+        ),
       ),
     );
 
@@ -89,7 +100,7 @@ export class UnicitySealQuorumSignaturesVerificationRule {
         'Unicity quorum signatures verification threshold reached',
         results,
       );
-      UnicitySealQuorumSignaturesVerificationRule.remember(trustBase, cacheKey, result);
+      UnicitySealQuorumSignaturesVerificationRule.remember(signatureVerifier, cacheKey, result);
 
       return result;
     }
@@ -103,23 +114,44 @@ export class UnicitySealQuorumSignaturesVerificationRule {
   }
 
   /**
-   * Store a quorum-reaching outcome, evicting the oldest entry once the trust
-   * base's cache is full (`Map` iterates in insertion order).
+   * Build the content-addressed cache key for a (trust base, seal) pair.
    *
-   * @param {RootTrustBase} trustBase Trust base the outcome was verified against.
-   * @param {string} cacheKey Hash of the seal's complete encoding.
+   * Both halves are hashed rather than referenced by identity so that mutating
+   * either in place produces a different key — a miss — rather than a stale hit.
+   *
+   * @param {RootTrustBase} trustBase Trust base the seal is verified against.
+   * @param {UnicitySeal} unicitySeal Seal being verified.
+   * @returns {Promise<string>} Cache key.
+   */
+  private static async cacheKeyFor(trustBase: RootTrustBase, unicitySeal: UnicitySeal): Promise<string> {
+    const [trustBaseHash, sealHash] = await Promise.all([
+      new DataHasher(HashAlgorithm.SHA256)
+        .update(new TextEncoder().encode(JSON.stringify(trustBase.toJSON())))
+        .digest(),
+      new DataHasher(HashAlgorithm.SHA256).update(unicitySeal.toCBOR()).digest(),
+    ]);
+
+    return `${HexConverter.encode(trustBaseHash.imprint)}:${HexConverter.encode(sealHash.imprint)}`;
+  }
+
+  /**
+   * Store a quorum-reaching outcome, evicting the oldest entry once that
+   * verifier's cache is full (`Map` iterates in insertion order).
+   *
+   * @param {ISignatureVerifier<Signature>} signatureVerifier Verifier that produced the outcome.
+   * @param {string} cacheKey Combined trust-base and seal key.
    * @param {VerificationResult<VerificationStatus>} result Outcome to memoise.
    * @returns {void}
    */
   private static remember(
-    trustBase: RootTrustBase,
+    signatureVerifier: ISignatureVerifier<Signature>,
     cacheKey: string,
     result: VerificationResult<VerificationStatus>,
   ): void {
-    let seals = UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.get(trustBase);
+    let seals = UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.get(signatureVerifier);
     if (!seals) {
       seals = new Map();
-      UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.set(trustBase, seals);
+      UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.set(signatureVerifier, seals);
     }
 
     if (seals.size >= UnicitySealQuorumSignaturesVerificationRule.MAX_CACHED_SEALS) {
@@ -134,6 +166,7 @@ export class UnicitySealQuorumSignaturesVerificationRule {
 
   private static async verifySignature(
     trustBase: RootTrustBase,
+    signatureVerifier: ISignatureVerifier<Signature>,
     nodeId: string,
     signature: Signature,
     hash: DataHash,
@@ -147,7 +180,7 @@ export class UnicitySealQuorumSignaturesVerificationRule {
       );
     }
 
-    const result = await SigningService.verifyWithPublicKey(hash, signature, node.signingKey);
+    const result = await signatureVerifier.verify(hash, signature, node.signingKey);
     if (!result) {
       return new VerificationResult(
         `SignatureVerificationRule[${nodeId}]`,

--- a/src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.ts
+++ b/src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.ts
@@ -3,6 +3,7 @@ import { DataHasher } from '../../../../crypto/hash/DataHasher.js';
 import { HashAlgorithm } from '../../../../crypto/hash/HashAlgorithm.js';
 import { ISignatureVerifier } from '../../../../crypto/ISignatureVerifier.js';
 import { Signature } from '../../../../crypto/secp256k1/Signature.js';
+import { CborSerializer } from '../../../../serialization/cbor/CborSerializer.js';
 import { HexConverter } from '../../../../util/HexConverter.js';
 import { VerificationResult } from '../../../../verification/VerificationResult.js';
 import { VerificationStatus } from '../../../../verification/VerificationStatus.js';
@@ -46,19 +47,25 @@ export class UnicitySealQuorumSignaturesVerificationRule {
    * The signature verifier needs no representation here: a cache is reachable
    * only through the rule that owns it, and a rule owns exactly one verifier.
    *
+   * Both are folded into a single digest through a CBOR array: the framing is
+   * what makes one hash safe, since concatenating two variable-length encodings
+   * raw would let a different (trust base, seal) split produce the same bytes.
+   *
    * @param {RootTrustBase} trustBase Trust base the seal is verified against.
    * @param {UnicitySeal} unicitySeal Seal being verified.
    * @returns {Promise<string>} Cache key.
    */
   private static async cacheKeyFor(trustBase: RootTrustBase, unicitySeal: UnicitySeal): Promise<string> {
-    const [trustBaseHash, sealHash] = await Promise.all([
-      new DataHasher(HashAlgorithm.SHA256)
-        .update(new TextEncoder().encode(JSON.stringify(trustBase.toJSON())))
-        .digest(),
-      new DataHasher(HashAlgorithm.SHA256).update(unicitySeal.toCBOR()).digest(),
-    ]);
+    const hash = await new DataHasher(HashAlgorithm.SHA256)
+      .update(
+        CborSerializer.encodeArray(
+          CborSerializer.encodeTextString(JSON.stringify(trustBase.toJSON())),
+          CborSerializer.encodeByteString(unicitySeal.toCBOR()),
+        ),
+      )
+      .digest();
 
-    return `${HexConverter.encode(trustBaseHash.imprint)}:${HexConverter.encode(sealHash.imprint)}`;
+    return HexConverter.encode(hash.imprint);
   }
 
   /**

--- a/src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.ts
+++ b/src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.ts
@@ -1,6 +1,9 @@
 import { DataHash } from '../../../../crypto/hash/DataHash.js';
+import { DataHasher } from '../../../../crypto/hash/DataHasher.js';
+import { HashAlgorithm } from '../../../../crypto/hash/HashAlgorithm.js';
 import { Signature } from '../../../../crypto/secp256k1/Signature.js';
 import { SigningService } from '../../../../crypto/secp256k1/SigningService.js';
+import { HexConverter } from '../../../../util/HexConverter.js';
 import { VerificationResult } from '../../../../verification/VerificationResult.js';
 import { VerificationStatus } from '../../../../verification/VerificationStatus.js';
 import { RootTrustBase } from '../../RootTrustBase.js';
@@ -11,7 +14,44 @@ import { UnicitySeal } from '../../UnicitySeal.js';
  */
 export class UnicitySealQuorumSignaturesVerificationRule {
   /**
+   * Upper bound on memoised seals per trust base. Certifications made in one
+   * batch land in a handful of adjacent aggregator rounds — measured on
+   * testnet2, twenty inclusion proofs shared three seals — so a small cache
+   * captures the clustering, while the bound stops a stream of distinct
+   * (including invalid-but-well-formed) seals from growing it without limit.
+   */
+  private static readonly MAX_CACHED_SEALS = 256;
+
+  /**
+   * Seals that have already reached quorum, keyed by trust base instance and
+   * then by the hash of the seal's **complete** encoding.
+   *
+   * Two subtleties make this sound:
+   *
+   * 1. The key covers the signatures. {@link UnicitySeal.calculateHash} hashes
+   *    the seal *without* them — it is the digest the root nodes sign — so
+   *    keying on it would let a seal's valid signatures be swapped for garbage
+   *    and still hit a cached OK. The key here is over `toCBOR()`, which
+   *    encodes the signatures too, so a cache hit means byte-identical input.
+   * 2. The trust base is part of the key by instance identity (a `WeakMap`),
+   *    since the outcome depends on its root nodes and quorum threshold.
+   *    `RootTrustBase` fields are readonly, so an instance cannot change
+   *    underneath the cache; a different instance simply misses.
+   *
+   * Only quorum-reaching outcomes are stored: a failure is the abnormal path,
+   * and not caching it keeps a flood of bad seals from evicting good entries.
+   */
+  private static readonly VERIFIED_SEALS = new WeakMap<
+    RootTrustBase,
+    Map<string, VerificationResult<VerificationStatus>>
+  >();
+
+  /**
    * Verify the unicity seal carries a quorum of valid root-node signatures.
+   *
+   * Signature verification dominates inclusion-proof verification, and every
+   * proof certified in the same aggregator round carries the same seal, so a
+   * verified seal is memoised (see {@link VERIFIED_SEALS}).
    *
    * @param {RootTrustBase} trustBase Root trust base.
    * @param {UnicitySeal} unicitySeal Seal to verify.
@@ -21,6 +61,14 @@ export class UnicitySealQuorumSignaturesVerificationRule {
     trustBase: RootTrustBase,
     unicitySeal: UnicitySeal,
   ): Promise<VerificationResult<VerificationStatus>> {
+    const cacheKey = HexConverter.encode(
+      (await new DataHasher(HashAlgorithm.SHA256).update(unicitySeal.toCBOR()).digest()).imprint,
+    );
+    const cached = UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.get(trustBase)?.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
     const hash = await unicitySeal.calculateHash();
 
     const results = await Promise.all(
@@ -35,12 +83,15 @@ export class UnicitySealQuorumSignaturesVerificationRule {
       0,
     );
     if (successful >= trustBase.quorumThreshold) {
-      return new VerificationResult(
+      const result = new VerificationResult(
         'UnicitySealQuorumSignaturesVerificationRule',
         VerificationStatus.OK,
         'Unicity quorum signatures verification threshold reached',
         results,
       );
+      UnicitySealQuorumSignaturesVerificationRule.remember(trustBase, cacheKey, result);
+
+      return result;
     }
 
     return new VerificationResult(
@@ -49,6 +100,36 @@ export class UnicitySealQuorumSignaturesVerificationRule {
       'Not enough unicity quorum signatures verification succeeded',
       results,
     );
+  }
+
+  /**
+   * Store a quorum-reaching outcome, evicting the oldest entry once the trust
+   * base's cache is full (`Map` iterates in insertion order).
+   *
+   * @param {RootTrustBase} trustBase Trust base the outcome was verified against.
+   * @param {string} cacheKey Hash of the seal's complete encoding.
+   * @param {VerificationResult<VerificationStatus>} result Outcome to memoise.
+   * @returns {void}
+   */
+  private static remember(
+    trustBase: RootTrustBase,
+    cacheKey: string,
+    result: VerificationResult<VerificationStatus>,
+  ): void {
+    let seals = UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.get(trustBase);
+    if (!seals) {
+      seals = new Map();
+      UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.set(trustBase, seals);
+    }
+
+    if (seals.size >= UnicitySealQuorumSignaturesVerificationRule.MAX_CACHED_SEALS) {
+      const oldest = seals.keys().next();
+      if (!oldest.done) {
+        seals.delete(oldest.value);
+      }
+    }
+
+    seals.set(cacheKey, result);
   }
 
   private static async verifySignature(

--- a/src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.ts
+++ b/src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.ts
@@ -8,116 +8,43 @@ import { VerificationResult } from '../../../../verification/VerificationResult.
 import { VerificationStatus } from '../../../../verification/VerificationStatus.js';
 import { RootTrustBase } from '../../RootTrustBase.js';
 import { UnicitySeal } from '../../UnicitySeal.js';
+import { VerifiedSealCache } from '../VerifiedSealCache.js';
 
 /**
  * Rule to verify that the UnicitySeal contains valid quorum signatures.
+ *
+ * Signature verification dominates inclusion-proof verification, and every proof
+ * certified in the same aggregator round carries the same seal, so the rule can
+ * memoise verified seals in a caller-supplied {@link VerifiedSealCache}.
  */
 export class UnicitySealQuorumSignaturesVerificationRule {
   /**
-   * Upper bound on memoised seals per trust base. Certifications made in one
-   * batch land in a handful of adjacent aggregator rounds — measured on
-   * testnet2, twenty inclusion proofs shared three seals — so a small cache
-   * captures the clustering, while the bound stops a stream of distinct
-   * (including invalid-but-well-formed) seals from growing it without limit.
-   */
-  private static readonly MAX_CACHED_SEALS = 256;
-
-  /**
-   * Seals that have already reached quorum, keyed by signature verifier and
-   * then by the hashes of the trust base and of the seal's complete encoding.
-   *
-   * Every part of that key is load-bearing:
-   *
-   * 1. The seal key covers the signatures. {@link UnicitySeal.calculateHash}
-   *    hashes the seal *without* them — it is the digest the root nodes sign —
-   *    so keying on it would let a seal's valid signatures be swapped for
-   *    garbage and still hit a cached OK. The key here is over `toCBOR()`,
-   *    which encodes the signatures too, so a hit means byte-identical input.
-   * 2. The trust base decides the outcome through its root nodes and quorum
-   *    threshold, so it is keyed by *content*, not by instance identity:
-   *    `RootTrustBase` exposes `_rootNodes` as a `Map`, and `readonly` stops
-   *    only reassignment, so an application that mutates it in place would
-   *    otherwise keep hitting verdicts computed under the old root keys.
-   * 3. The verifier decides the outcome too, and verifiers are pluggable and
-   *    need not agree — one that binds the recovery byte rejects signatures
-   *    that one checking only `(r, s)` accepts. Keying on the verifier instance
-   *    keeps a verdict from leaking across that boundary.
-   *
-   * Only quorum-reaching outcomes are stored: a failure is the abnormal path,
-   * and not caching it keeps a flood of bad seals from evicting good entries.
-   */
-  private static readonly VERIFIED_SEALS = new WeakMap<
-    ISignatureVerifier<Signature>,
-    Map<string, VerificationResult<VerificationStatus>>
-  >();
-
-  /**
-   * Verify the unicity seal carries a quorum of valid root-node signatures.
-   *
-   * Signature verification dominates inclusion-proof verification, and every
-   * proof certified in the same aggregator round carries the same seal, so a
-   * verified seal is memoised (see {@link VERIFIED_SEALS}).
-   *
-   * @param {RootTrustBase} trustBase Root trust base.
    * @param {ISignatureVerifier<Signature>} signatureVerifier Verifier for the root-node signatures.
-   * @param {UnicitySeal} unicitySeal Seal to verify.
-   * @returns {Promise<VerificationResult<VerificationStatus>>} Verification outcome.
+   * @param {VerifiedSealCache} [cache] Memo for verified seals; omit to verify every seal afresh.
    */
-  public static async verify(
-    trustBase: RootTrustBase,
-    signatureVerifier: ISignatureVerifier<Signature>,
-    unicitySeal: UnicitySeal,
-  ): Promise<VerificationResult<VerificationStatus>> {
-    const cacheKey = await UnicitySealQuorumSignaturesVerificationRule.cacheKeyFor(trustBase, unicitySeal);
-    const cached = UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.get(signatureVerifier)?.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-
-    const hash = await unicitySeal.calculateHash();
-
-    const results = await Promise.all(
-      Array.from(unicitySeal.signatures?.entries() ?? []).map(([nodeId, signature]) =>
-        UnicitySealQuorumSignaturesVerificationRule.verifySignature(
-          trustBase,
-          signatureVerifier,
-          nodeId,
-          signature,
-          hash,
-        ),
-      ),
-    );
-
-    const successful = results.reduce(
-      (previousValue, currentValue) =>
-        currentValue.status === VerificationStatus.OK ? previousValue + 1 : previousValue,
-      0,
-    );
-    if (successful >= trustBase.quorumThreshold) {
-      const result = new VerificationResult(
-        'UnicitySealQuorumSignaturesVerificationRule',
-        VerificationStatus.OK,
-        'Unicity quorum signatures verification threshold reached',
-        results,
-      );
-      UnicitySealQuorumSignaturesVerificationRule.remember(signatureVerifier, cacheKey, result);
-
-      return result;
-    }
-
-    return new VerificationResult(
-      'UnicitySealQuorumSignaturesVerificationRule',
-      VerificationStatus.FAIL,
-      'Not enough unicity quorum signatures verification succeeded',
-      results,
-    );
-  }
+  public constructor(
+    private readonly signatureVerifier: ISignatureVerifier<Signature>,
+    private readonly cache?: VerifiedSealCache,
+  ) {}
 
   /**
-   * Build the content-addressed cache key for a (trust base, seal) pair.
+   * Build the cache key for a (trust base, seal) pair.
    *
-   * Both halves are hashed rather than referenced by identity so that mutating
-   * either in place produces a different key — a miss — rather than a stale hit.
+   * Both halves are addressed by content, and both are load-bearing:
+   *
+   * 1. The seal is keyed on its **complete** encoding.
+   *    {@link UnicitySeal.calculateHash} hashes it *without* the signatures — it
+   *    is the digest the root nodes sign — so keying on that would let a seal's
+   *    valid signatures be swapped for garbage and still hit a cached OK.
+   *    `toCBOR()` encodes the signatures too, so a hit means identical bytes.
+   * 2. The trust base decides the outcome through its root nodes and quorum
+   *    threshold, and is keyed by content rather than identity because
+   *    `RootTrustBase` exposes `_rootNodes` as a `Map`: `readonly` stops only
+   *    reassignment, so an in-place edit would otherwise keep hitting verdicts
+   *    computed under the old root keys.
+   *
+   * The signature verifier needs no representation here: a cache is reachable
+   * only through the rule that owns it, and a rule owns exactly one verifier.
    *
    * @param {RootTrustBase} trustBase Trust base the seal is verified against.
    * @param {UnicitySeal} unicitySeal Seal being verified.
@@ -135,38 +62,66 @@ export class UnicitySealQuorumSignaturesVerificationRule {
   }
 
   /**
-   * Store a quorum-reaching outcome, evicting the oldest entry once that
-   * verifier's cache is full (`Map` iterates in insertion order).
+   * Verify the unicity seal carries a quorum of valid root-node signatures.
    *
-   * @param {ISignatureVerifier<Signature>} signatureVerifier Verifier that produced the outcome.
-   * @param {string} cacheKey Combined trust-base and seal key.
-   * @param {VerificationResult<VerificationStatus>} result Outcome to memoise.
-   * @returns {void}
+   * @param {RootTrustBase} trustBase Root trust base.
+   * @param {UnicitySeal} unicitySeal Seal to verify.
+   * @returns {Promise<VerificationResult<VerificationStatus>>} Verification outcome.
    */
-  private static remember(
-    signatureVerifier: ISignatureVerifier<Signature>,
-    cacheKey: string,
-    result: VerificationResult<VerificationStatus>,
-  ): void {
-    let seals = UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.get(signatureVerifier);
-    if (!seals) {
-      seals = new Map();
-      UnicitySealQuorumSignaturesVerificationRule.VERIFIED_SEALS.set(signatureVerifier, seals);
-    }
-
-    if (seals.size >= UnicitySealQuorumSignaturesVerificationRule.MAX_CACHED_SEALS) {
-      const oldest = seals.keys().next();
-      if (!oldest.done) {
-        seals.delete(oldest.value);
+  public async verify(
+    trustBase: RootTrustBase,
+    unicitySeal: UnicitySeal,
+  ): Promise<VerificationResult<VerificationStatus>> {
+    const cacheKey = this.cache
+      ? await UnicitySealQuorumSignaturesVerificationRule.cacheKeyFor(trustBase, unicitySeal)
+      : null;
+    if (cacheKey !== null) {
+      const cached = this.cache?.get(cacheKey) ?? null;
+      if (cached !== null) {
+        return cached;
       }
     }
 
-    seals.set(cacheKey, result);
+    const hash = await unicitySeal.calculateHash();
+
+    const results = await Promise.all(
+      Array.from(unicitySeal.signatures?.entries() ?? []).map(([nodeId, signature]) =>
+        this.verifySignature(trustBase, nodeId, signature, hash),
+      ),
+    );
+
+    const successful = results.reduce(
+      (previousValue, currentValue) =>
+        currentValue.status === VerificationStatus.OK ? previousValue + 1 : previousValue,
+      0,
+    );
+    if (successful >= trustBase.quorumThreshold) {
+      const result = new VerificationResult(
+        'UnicitySealQuorumSignaturesVerificationRule',
+        VerificationStatus.OK,
+        'Unicity quorum signatures verification threshold reached',
+        results,
+      );
+      // Only quorum-reaching outcomes are memoised: a failure is the abnormal
+      // path, and not caching it keeps a flood of bad seals from evicting good
+      // entries.
+      if (cacheKey !== null) {
+        this.cache?.set(cacheKey, result);
+      }
+
+      return result;
+    }
+
+    return new VerificationResult(
+      'UnicitySealQuorumSignaturesVerificationRule',
+      VerificationStatus.FAIL,
+      'Not enough unicity quorum signatures verification succeeded',
+      results,
+    );
   }
 
-  private static async verifySignature(
+  private async verifySignature(
     trustBase: RootTrustBase,
-    signatureVerifier: ISignatureVerifier<Signature>,
     nodeId: string,
     signature: Signature,
     hash: DataHash,
@@ -180,7 +135,7 @@ export class UnicitySealQuorumSignaturesVerificationRule {
       );
     }
 
-    const result = await signatureVerifier.verify(hash, signature, node.signingKey);
+    const result = await this.signatureVerifier.verify(hash, signature, node.signingKey);
     if (!result) {
       return new VerificationResult(
         `SignatureVerificationRule[${nodeId}]`,

--- a/src/crypto/ISignatureVerifier.ts
+++ b/src/crypto/ISignatureVerifier.ts
@@ -1,0 +1,27 @@
+import type { DataHash } from './hash/DataHash.js';
+import { ISignature } from './ISignature.js';
+
+/**
+ * Verifies signatures of type `T` against an expected public key.
+ *
+ * Kept separate from {@link ISigningService} so that verification — which
+ * dominates token verification — can be swapped for another algorithm or a
+ * faster implementation (native bindings, an HSM, batching) without touching
+ * signing. The dependency direction is signing → verification, never the
+ * reverse.
+ *
+ * @typeParam T Signature type this verifier consumes.
+ */
+export interface ISignatureVerifier<T extends ISignature> {
+  readonly algorithm: string;
+
+  /**
+   * Verify `signature` over `hash` against `publicKey`.
+   *
+   * @param {DataHash} hash Signed hash.
+   * @param {T} signature Signature to verify.
+   * @param {Uint8Array} publicKey Expected public key.
+   * @returns {Promise<boolean>} True if the signature verifies.
+   */
+  verify(hash: DataHash, signature: T, publicKey: Uint8Array): Promise<boolean>;
+}

--- a/src/crypto/secp256k1/Secp256k1SignatureVerifier.ts
+++ b/src/crypto/secp256k1/Secp256k1SignatureVerifier.ts
@@ -1,0 +1,44 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+
+import { Signature } from './Signature.js';
+import { areUint8ArraysEqual } from '../../util/TypedArrayUtils.js';
+import { DataHash } from '../hash/DataHash.js';
+import { ISignatureVerifier } from '../ISignatureVerifier.js';
+
+/**
+ * secp256k1 signature verification.
+ *
+ * Verification here *is* key recovery: the key recovered from `(r, s)` and the
+ * recovery byte over `hash` is by construction the only key under which the
+ * signature verifies, so comparing it against the expected key both
+ * authenticates the signature and binds the recovery byte — a tampered recovery
+ * byte fails. That is one EC operation where recover-then-verify needs two.
+ *
+ * Recovery, unlike `secp256k1.verify` (noble applies `lowS: true` by default),
+ * accepts malleable high-s signatures, so the low-s policy is applied
+ * explicitly and behaviour is unchanged.
+ */
+export class Secp256k1SignatureVerifier implements ISignatureVerifier<Signature> {
+  public readonly algorithm: string = 'secp256k1';
+
+  /**
+   * @inheritDoc
+   */
+  public verify(hash: DataHash, signature: Signature, publicKey: Uint8Array): Promise<boolean> {
+    try {
+      const recoverable = secp256k1.Signature.fromBytes(
+        new Uint8Array([signature.recovery, ...signature.bytes]),
+        'recovered',
+      );
+      if (recoverable.hasHighS()) {
+        return Promise.resolve(false);
+      }
+
+      return Promise.resolve(
+        areUint8ArraysEqual(new Uint8Array(publicKey), recoverable.recoverPublicKey(hash.data).toBytes()),
+      );
+    } catch {
+      return Promise.resolve(false);
+    }
+  }
+}

--- a/src/crypto/secp256k1/SigningService.ts
+++ b/src/crypto/secp256k1/SigningService.ts
@@ -88,12 +88,12 @@ export class SigningService implements ISigningService<Signature> {
    *   recovered public key matches `publicKey`.
    */
   public static verifyWithPublicKey(hash: DataHash, signature: Signature, publicKey: Uint8Array): Promise<boolean> {
-    const expectedPublicKey = new Uint8Array(publicKey);
-    if (!areUint8ArraysEqual(expectedPublicKey, SigningService.recoverPublicKey(hash, signature))) {
+    const recovered = SigningService.recoverSignature(hash, signature);
+    if (recovered === null || recovered.hasHighS) {
       return Promise.resolve(false);
     }
 
-    return SigningService.verify(hash, signature.bytes, expectedPublicKey);
+    return Promise.resolve(areUint8ArraysEqual(new Uint8Array(publicKey), recovered.publicKey));
   }
 
   /**
@@ -106,28 +106,43 @@ export class SigningService implements ISigningService<Signature> {
    * @returns {Promise<boolean>} True if the signature verifies.
    */
   public static verifyWithRecoveredPublicKey(hash: DataHash, signature: Signature): Promise<boolean> {
-    const recoveredPublicKey = SigningService.recoverPublicKey(hash, signature);
-    if (recoveredPublicKey === null) {
+    const recovered = SigningService.recoverSignature(hash, signature);
+    if (recovered === null) {
       return Promise.resolve(false);
     }
 
-    return SigningService.verify(hash, signature.bytes, recoveredPublicKey);
+    return SigningService.verify(hash, signature.bytes, recovered.publicKey);
   }
 
   /**
    * Recover the compressed public key that produced `signature` over `hash`,
-   * using the signature's recovery byte.
+   * together with the signature's malleability flag, parsing the signature once.
+   *
+   * Key recovery is itself the validity check: the recovered key is by
+   * construction the only key under which `(r, s)` verifies for `hash`, so a
+   * caller that compares it against an expected key needs no second EC
+   * verification. `hasHighS` is returned alongside because recovery — unlike
+   * `secp256k1.verify`, which applies noble's default `lowS: true` policy —
+   * accepts malleable signatures, so callers relying on recovery alone must
+   * reject high-s themselves.
    *
    * @param {DataHash} hash Hash that was signed.
    * @param {Signature} signature Recoverable signature.
-   * @returns {Uint8Array|null} Recovered compressed public key, or `null` if the
-   *   signature is not recoverable (e.g. `r`/`s` out of range).
+   * @returns {{ hasHighS: boolean; publicKey: Uint8Array }|null} Recovered public
+   *   key and malleability flag, or `null` if the signature is not recoverable
+   *   (e.g. `r`/`s` out of range).
    */
-  private static recoverPublicKey(hash: DataHash, signature: Signature): Uint8Array | null {
+  private static recoverSignature(
+    hash: DataHash,
+    signature: Signature,
+  ): { hasHighS: boolean; publicKey: Uint8Array } | null {
     try {
-      return secp256k1.Signature.fromBytes(new Uint8Array([signature.recovery, ...signature.bytes]), 'recovered')
-        .recoverPublicKey(hash.data)
-        .toBytes();
+      const recoverable = secp256k1.Signature.fromBytes(
+        new Uint8Array([signature.recovery, ...signature.bytes]),
+        'recovered',
+      );
+
+      return { hasHighS: recoverable.hasHighS(), publicKey: recoverable.recoverPublicKey(hash.data).toBytes() };
     } catch {
       return null;
     }

--- a/src/crypto/secp256k1/SigningService.ts
+++ b/src/crypto/secp256k1/SigningService.ts
@@ -1,18 +1,23 @@
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 
+import { Secp256k1SignatureVerifier } from './Secp256k1SignatureVerifier.js';
 import { ISigningService } from '../ISigningService.js';
 import { Signature } from './Signature.js';
-import { areUint8ArraysEqual } from '../../util/TypedArrayUtils.js';
 import { DataHash } from '../hash/DataHash.js';
 
 /**
  * Default secp256k1 signing service. Wraps a 32-byte private key and exposes
- * the matching compressed public key, plus helpers for sign/verify and for
- * recovering a public key from a signature.
+ * the matching compressed public key, plus helpers for sign/verify.
+ *
+ * Verification is delegated to {@link Secp256k1SignatureVerifier}: signing
+ * depends on verification, never the reverse.
  *
  * @implements {ISigningService}
  */
 export class SigningService implements ISigningService<Signature> {
+  /** Stateless, so one shared instance serves every caller. */
+  private static readonly SIGNATURE_VERIFIER = new Secp256k1SignatureVerifier();
+
   private readonly _publicKey: Uint8Array;
 
   public constructor(private readonly privateKey: Uint8Array) {
@@ -88,64 +93,7 @@ export class SigningService implements ISigningService<Signature> {
    *   recovered public key matches `publicKey`.
    */
   public static verifyWithPublicKey(hash: DataHash, signature: Signature, publicKey: Uint8Array): Promise<boolean> {
-    const recovered = SigningService.recoverSignature(hash, signature);
-    if (recovered === null || recovered.hasHighS) {
-      return Promise.resolve(false);
-    }
-
-    return Promise.resolve(areUint8ArraysEqual(new Uint8Array(publicKey), recovered.publicKey));
-  }
-
-  /**
-   * Recover the public key from the signature's recovery byte and verify the
-   * signature against `hash`. The recovered key defines the signer's identity;
-   * no expected key is supplied.
-   *
-   * @param {DataHash} hash Hash that was signed.
-   * @param {Signature} signature Recoverable signature.
-   * @returns {Promise<boolean>} True if the signature verifies.
-   */
-  public static verifyWithRecoveredPublicKey(hash: DataHash, signature: Signature): Promise<boolean> {
-    const recovered = SigningService.recoverSignature(hash, signature);
-    if (recovered === null) {
-      return Promise.resolve(false);
-    }
-
-    return SigningService.verify(hash, signature.bytes, recovered.publicKey);
-  }
-
-  /**
-   * Recover the compressed public key that produced `signature` over `hash`,
-   * together with the signature's malleability flag, parsing the signature once.
-   *
-   * Key recovery is itself the validity check: the recovered key is by
-   * construction the only key under which `(r, s)` verifies for `hash`, so a
-   * caller that compares it against an expected key needs no second EC
-   * verification. `hasHighS` is returned alongside because recovery — unlike
-   * `secp256k1.verify`, which applies noble's default `lowS: true` policy —
-   * accepts malleable signatures, so callers relying on recovery alone must
-   * reject high-s themselves.
-   *
-   * @param {DataHash} hash Hash that was signed.
-   * @param {Signature} signature Recoverable signature.
-   * @returns {{ hasHighS: boolean; publicKey: Uint8Array }|null} Recovered public
-   *   key and malleability flag, or `null` if the signature is not recoverable
-   *   (e.g. `r`/`s` out of range).
-   */
-  private static recoverSignature(
-    hash: DataHash,
-    signature: Signature,
-  ): { hasHighS: boolean; publicKey: Uint8Array } | null {
-    try {
-      const recoverable = secp256k1.Signature.fromBytes(
-        new Uint8Array([signature.recovery, ...signature.bytes]),
-        'recovered',
-      );
-
-      return { hasHighS: recoverable.hasHighS(), publicKey: recoverable.recoverPublicKey(hash.data).toBytes() };
-    } catch {
-      return null;
-    }
+    return SigningService.SIGNATURE_VERIFIER.verify(hash, signature, publicKey);
   }
 
   /**

--- a/src/predicate/builtin/DefaultBuiltInPredicateVerifier.ts
+++ b/src/predicate/builtin/DefaultBuiltInPredicateVerifier.ts
@@ -1,4 +1,5 @@
 import { DataHash } from '../../crypto/hash/DataHash.js';
+import { Secp256k1SignatureVerifier } from '../../crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { CborDeserializer } from '../../serialization/cbor/CborDeserializer.js';
 import { VerificationResult } from '../../verification/VerificationResult.js';
 import { VerificationStatus } from '../../verification/VerificationStatus.js';
@@ -32,12 +33,15 @@ export class DefaultBuiltInPredicateVerifier implements IPredicateVerifier {
   }
 
   /**
-   * Create a verifier preloaded with the default built-in predicate verifiers.
+   * Create a verifier preloaded with the default built-in predicate verifiers,
+   * wired to secp256k1. To use a different signature verifier, compose the
+   * registry directly:
+   * `new DefaultBuiltInPredicateVerifier([new SignaturePredicateVerifier(myVerifier)])`.
    *
    * @returns {DefaultBuiltInPredicateVerifier} New verifier.
    */
   public static create(): DefaultBuiltInPredicateVerifier {
-    return new DefaultBuiltInPredicateVerifier([new SignaturePredicateVerifier()]);
+    return new DefaultBuiltInPredicateVerifier([new SignaturePredicateVerifier(new Secp256k1SignatureVerifier())]);
   }
 
   /**

--- a/src/predicate/builtin/verification/SignaturePredicateVerifier.ts
+++ b/src/predicate/builtin/verification/SignaturePredicateVerifier.ts
@@ -1,7 +1,8 @@
 import { DataHash } from '../../../crypto/hash/DataHash.js';
 import { DataHasher } from '../../../crypto/hash/DataHasher.js';
 import { HashAlgorithm } from '../../../crypto/hash/HashAlgorithm.js';
-import { SigningService } from '../../../crypto/secp256k1/SigningService.js';
+import { ISignatureVerifier } from '../../../crypto/ISignatureVerifier.js';
+import { Signature } from '../../../crypto/secp256k1/Signature.js';
 import { CborSerializer } from '../../../serialization/cbor/CborSerializer.js';
 import { VerificationResult } from '../../../verification/VerificationResult.js';
 import { VerificationStatus } from '../../../verification/VerificationStatus.js';
@@ -13,11 +14,16 @@ import { SignaturePredicateUnlockScript } from '../SignaturePredicateUnlockScrip
 
 /**
  * Verifier for {@link SignaturePredicate}: recomputes the
- * (sourceStateHash, transactionHash) digest and checks the secp256k1
- * signature in the unlock script against the predicate's public key.
+ * (sourceStateHash, transactionHash) digest and checks the signature in the
+ * unlock script against the predicate's public key.
  */
 export class SignaturePredicateVerifier implements IBuiltInPredicateVerifier {
   public readonly type = BuiltInPredicateType.Signature;
+
+  /**
+   * @param {ISignatureVerifier<Signature>} signatureVerifier Verifier for unlock-script signatures.
+   */
+  public constructor(private readonly signatureVerifier: ISignatureVerifier<Signature>) {}
 
   /**
    * @inheritDoc
@@ -31,7 +37,7 @@ export class SignaturePredicateVerifier implements IBuiltInPredicateVerifier {
     const predicate = SignaturePredicate.fromPredicate(encodedPredicate);
     const unlockScript = SignaturePredicateUnlockScript.decode(unlockScriptBytes);
 
-    const result = await SigningService.verifyWithPublicKey(
+    const result = await this.signatureVerifier.verify(
       await new DataHasher(HashAlgorithm.SHA256)
         .update(
           CborSerializer.encodeArray(

--- a/src/transaction/CertifiedMintTransaction.ts
+++ b/src/transaction/CertifiedMintTransaction.ts
@@ -5,6 +5,7 @@ import { TokenId } from './TokenId.js';
 import { TokenSalt } from './TokenSalt.js';
 import { TokenType } from './TokenType.js';
 import { RootTrustBase } from '../api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../api/bft/verification/UnicityCertificateVerifier.js';
 import { InclusionProof } from '../api/InclusionProof.js';
 import { NetworkId } from '../api/NetworkId.js';
 import { DataHash } from '../crypto/hash/DataHash.js';
@@ -116,6 +117,7 @@ export class CertifiedMintTransaction implements ITransaction {
    *
    * @param {RootTrustBase} trustBase Root trust base used to verify the inclusion certificate.
    * @param {PredicateVerifierService} predicateVerifier Verifier for any embedded predicates.
+   * @param {UnicityCertificateVerifier} unicityCertificateVerifier Unicity certificate verifier.
    * @param {MintTransaction} transaction Transaction to certify.
    * @param {InclusionProof} inclusionProof Inclusion proof for the transaction.
    * @returns {Promise<CertifiedMintTransaction>} Verified certified transaction.
@@ -124,12 +126,14 @@ export class CertifiedMintTransaction implements ITransaction {
   public static async fromTransaction(
     trustBase: RootTrustBase,
     predicateVerifier: PredicateVerifierService,
+    unicityCertificateVerifier: UnicityCertificateVerifier,
     transaction: MintTransaction,
     inclusionProof: InclusionProof,
   ): Promise<CertifiedMintTransaction> {
     const result = await InclusionProofVerificationRule.verify(
       trustBase,
       predicateVerifier,
+      unicityCertificateVerifier,
       inclusionProof,
       await transaction.calculateTransactionHash(),
       transaction.lockScript,

--- a/src/transaction/CertifiedTransferTransaction.ts
+++ b/src/transaction/CertifiedTransferTransaction.ts
@@ -3,6 +3,7 @@ import { StateMask } from './StateMask.js';
 import { Token } from './Token.js';
 import { TransferTransaction } from './TransferTransaction.js';
 import { RootTrustBase } from '../api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../api/bft/verification/UnicityCertificateVerifier.js';
 import { InclusionProof } from '../api/InclusionProof.js';
 import { DataHash } from '../crypto/hash/DataHash.js';
 import { EncodedPredicate } from '../predicate/EncodedPredicate.js';
@@ -80,6 +81,7 @@ export class CertifiedTransferTransaction implements ITransaction {
    *
    * @param {RootTrustBase} trustBase Root trust base used to verify the inclusion certificate.
    * @param {PredicateVerifierService} predicateVerifier Verifier for any embedded predicates.
+   * @param {UnicityCertificateVerifier} unicityCertificateVerifier Unicity certificate verifier.
    * @param {TransferTransaction} transaction Transaction to certify.
    * @param {InclusionProof} inclusionProof Inclusion proof for the transaction.
    * @returns {Promise<CertifiedTransferTransaction>} Verified certified transaction.
@@ -88,12 +90,14 @@ export class CertifiedTransferTransaction implements ITransaction {
   public static async fromTransaction(
     trustBase: RootTrustBase,
     predicateVerifier: PredicateVerifierService,
+    unicityCertificateVerifier: UnicityCertificateVerifier,
     transaction: TransferTransaction,
     inclusionProof: InclusionProof,
   ): Promise<CertifiedTransferTransaction> {
     const result = await InclusionProofVerificationRule.verify(
       trustBase,
       predicateVerifier,
+      unicityCertificateVerifier,
       inclusionProof,
       await transaction.calculateTransactionHash(),
       transaction.lockScript,

--- a/src/transaction/MintTransaction.ts
+++ b/src/transaction/MintTransaction.ts
@@ -6,6 +6,7 @@ import { TokenId } from './TokenId.js';
 import { TokenSalt } from './TokenSalt.js';
 import { TokenType } from './TokenType.js';
 import { RootTrustBase } from '../api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../api/bft/verification/UnicityCertificateVerifier.js';
 import { InclusionProof } from '../api/InclusionProof.js';
 import { NetworkId } from '../api/NetworkId.js';
 import { DataHash } from '../crypto/hash/DataHash.js';
@@ -181,15 +182,23 @@ export class MintTransaction implements ITransaction {
    *
    * @param {RootTrustBase} trustBase Root trust base used to verify the inclusion certificate.
    * @param {PredicateVerifierService} predicateVerifier Verifier for any predicates.
+   * @param {UnicityCertificateVerifier} unicityCertificateVerifier Unicity certificate verifier.
    * @param {InclusionProof} inclusionProof Inclusion proof for this transaction.
    * @returns {Promise<CertifiedMintTransaction>} Verified certified transaction.
    */
   public toCertifiedTransaction(
     trustBase: RootTrustBase,
     predicateVerifier: PredicateVerifierService,
+    unicityCertificateVerifier: UnicityCertificateVerifier,
     inclusionProof: InclusionProof,
   ): Promise<CertifiedMintTransaction> {
-    return CertifiedMintTransaction.fromTransaction(trustBase, predicateVerifier, this, inclusionProof);
+    return CertifiedMintTransaction.fromTransaction(
+      trustBase,
+      predicateVerifier,
+      unicityCertificateVerifier,
+      this,
+      inclusionProof,
+    );
   }
 
   /**

--- a/src/transaction/TransferTransaction.ts
+++ b/src/transaction/TransferTransaction.ts
@@ -3,6 +3,7 @@ import { ITransaction } from './ITransaction.js';
 import { StateMask } from './StateMask.js';
 import { Token } from './Token.js';
 import { RootTrustBase } from '../api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../api/bft/verification/UnicityCertificateVerifier.js';
 import { InclusionProof } from '../api/InclusionProof.js';
 import { DataHash } from '../crypto/hash/DataHash.js';
 import { DataHasher } from '../crypto/hash/DataHasher.js';
@@ -148,15 +149,23 @@ export class TransferTransaction implements ITransaction {
    *
    * @param {RootTrustBase} trustBase Root trust base used to verify the inclusion certificate.
    * @param {PredicateVerifierService} predicateVerifier Verifier for any embedded predicates.
+   * @param {UnicityCertificateVerifier} unicityCertificateVerifier Unicity certificate verifier.
    * @param {InclusionProof} inclusionProof Inclusion proof for this transaction.
    * @returns {Promise<CertifiedTransferTransaction>} Verified certified transaction.
    */
   public toCertifiedTransaction(
     trustBase: RootTrustBase,
     predicateVerifier: PredicateVerifierService,
+    unicityCertificateVerifier: UnicityCertificateVerifier,
     inclusionProof: InclusionProof,
   ): Promise<CertifiedTransferTransaction> {
-    return CertifiedTransferTransaction.fromTransaction(trustBase, predicateVerifier, this, inclusionProof);
+    return CertifiedTransferTransaction.fromTransaction(
+      trustBase,
+      predicateVerifier,
+      unicityCertificateVerifier,
+      this,
+      inclusionProof,
+    );
   }
 
   /**

--- a/src/transaction/verification/IVerificationContext.ts
+++ b/src/transaction/verification/IVerificationContext.ts
@@ -1,6 +1,7 @@
 import { MintJustificationVerifierService } from './MintJustificationVerifierService.js';
 import { TokenIssuanceVerifierService } from './TokenIssuanceVerifierService.js';
 import { RootTrustBase } from '../../api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../../api/bft/verification/UnicityCertificateVerifier.js';
 import { PredicateVerifierService } from '../../predicate/verification/PredicateVerifierService.js';
 
 /**
@@ -15,4 +16,5 @@ export interface IVerificationContext {
   readonly predicateVerifier: PredicateVerifierService;
   readonly tokenIssuanceVerifier: TokenIssuanceVerifierService;
   readonly trustBase: RootTrustBase;
+  readonly unicityCertificateVerifier: UnicityCertificateVerifier;
 }

--- a/src/transaction/verification/VerificationContext.ts
+++ b/src/transaction/verification/VerificationContext.ts
@@ -2,6 +2,7 @@ import { IVerificationContext } from './IVerificationContext.js';
 import { MintJustificationVerifierService } from './MintJustificationVerifierService.js';
 import { TokenIssuanceVerifierService } from './TokenIssuanceVerifierService.js';
 import { RootTrustBase } from '../../api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../../api/bft/verification/UnicityCertificateVerifier.js';
 import { PredicateVerifierService } from '../../predicate/verification/PredicateVerifierService.js';
 
 /**
@@ -14,12 +15,14 @@ export class VerificationContext implements IVerificationContext {
   /**
    * @param {RootTrustBase} trustBase Root trust base for the network.
    * @param {PredicateVerifierService} predicateVerifier Predicate verifier.
+   * @param {UnicityCertificateVerifier} unicityCertificateVerifier Unicity certificate verifier.
    * @param {MintJustificationVerifierService} mintJustificationVerifier Mint justification registry.
    * @param {TokenIssuanceVerifierService} tokenIssuanceVerifier Token issuance registry.
    */
   public constructor(
     public readonly trustBase: RootTrustBase,
     public readonly predicateVerifier: PredicateVerifierService,
+    public readonly unicityCertificateVerifier: UnicityCertificateVerifier,
     public readonly mintJustificationVerifier: MintJustificationVerifierService,
     public readonly tokenIssuanceVerifier: TokenIssuanceVerifierService,
   ) {}

--- a/src/transaction/verification/rule/CertifiedMintTransactionVerificationRule.ts
+++ b/src/transaction/verification/rule/CertifiedMintTransactionVerificationRule.ts
@@ -59,6 +59,7 @@ export class CertifiedMintTransactionVerificationRule {
     result = await InclusionProofVerificationRule.verify(
       verificationContext.trustBase,
       verificationContext.predicateVerifier,
+      verificationContext.unicityCertificateVerifier,
       genesis.inclusionProof,
       await genesis.calculateTransactionHash(),
       genesis.lockScript,

--- a/src/transaction/verification/rule/CertifiedTransferTransactionVerificationRule.ts
+++ b/src/transaction/verification/rule/CertifiedTransferTransactionVerificationRule.ts
@@ -23,6 +23,7 @@ export class CertifiedTransferTransactionVerificationRule {
     const result: VerificationResult<unknown> = await InclusionProofVerificationRule.verify(
       verificationContext.trustBase,
       verificationContext.predicateVerifier,
+      verificationContext.unicityCertificateVerifier,
       transaction.inclusionProof,
       await transaction.calculateTransactionHash(),
       transaction.lockScript,

--- a/src/transaction/verification/rule/InclusionProofVerificationRule.ts
+++ b/src/transaction/verification/rule/InclusionProofVerificationRule.ts
@@ -1,6 +1,6 @@
 import { ShardIdMatchesStateIdRule } from './ShardIdMatchesStateIdRule.js';
 import { RootTrustBase } from '../../../api/bft/RootTrustBase.js';
-import { UnicityCertificateVerification } from '../../../api/bft/verification/UnicityCertificateVerification.js';
+import { UnicityCertificateVerifier } from '../../../api/bft/verification/UnicityCertificateVerifier.js';
 import { InclusionProof } from '../../../api/InclusionProof.js';
 import { StateId } from '../../../api/StateId.js';
 import { DataHash } from '../../../crypto/hash/DataHash.js';
@@ -45,6 +45,7 @@ export class InclusionProofVerificationRule {
   public static async verify(
     trustBase: RootTrustBase,
     predicateVerifierFactory: PredicateVerifierService,
+    unicityCertificateVerifier: UnicityCertificateVerifier,
     inclusionProof: InclusionProof,
     transactionHash: DataHash,
     lockScript: EncodedPredicate,
@@ -105,7 +106,7 @@ export class InclusionProofVerificationRule {
       );
     }
 
-    const unicityCertificateVerificationResult = await UnicityCertificateVerification.verify(trustBase, inclusionProof);
+    const unicityCertificateVerificationResult = await unicityCertificateVerifier.verify(trustBase, inclusionProof);
 
     if (unicityCertificateVerificationResult.status !== VerificationStatus.OK) {
       return new VerificationResult(

--- a/src/transaction/verification/worker/WorkerTokenVerifier.ts
+++ b/src/transaction/verification/worker/WorkerTokenVerifier.ts
@@ -2,6 +2,7 @@ import { ITokenVerifier } from '../ITokenVerifier.js';
 import { IVerificationContext } from '../IVerificationContext.js';
 import { IWorker } from './IWorker.js';
 import { RootTrustBase } from '../../../api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../../../api/bft/verification/UnicityCertificateVerifier.js';
 import { InclusionProof } from '../../../api/InclusionProof.js';
 import { DataHash } from '../../../crypto/hash/DataHash.js';
 import { DataHasher } from '../../../crypto/hash/DataHasher.js';
@@ -188,16 +189,19 @@ class WorkerTransferTransaction {
    *
    * @param {RootTrustBase} trustBase Root trust base.
    * @param {PredicateVerifierService} predicateVerifier Predicate verifier.
+   * @param {UnicityCertificateVerifier} unicityCertificateVerifier Unicity certificate verifier.
    * @returns {Promise<VerificationResult<VerificationStatus>>} Verification outcome.
    */
   public async verify(
     trustBase: RootTrustBase,
     predicateVerifier: PredicateVerifierService,
+    unicityCertificateVerifier: UnicityCertificateVerifier,
   ): Promise<VerificationResult<VerificationStatus>> {
     const results: VerificationResult<unknown>[] = [];
     const result = await InclusionProofVerificationRule.verify(
       trustBase,
       predicateVerifier,
+      unicityCertificateVerifier,
       this.inclusionProof,
       await this.calculateTransactionHash(),
       this.lockScript,
@@ -237,6 +241,16 @@ export abstract class TransferTransactionVerifier {
   protected abstract get predicateVerifier(): PredicateVerifierService;
 
   /**
+   * Unicity certificate verifier for worker-side inclusion-proof checks.
+   *
+   * Verifier instances cannot cross the worker boundary, so each side builds
+   * its own; this one MUST be equivalent to the one in the main-thread
+   * verification context. If they differ, worker-verified transfers and the
+   * main-thread-verified genesis are judged under different rules.
+   */
+  protected abstract get unicityCertificateVerifier(): UnicityCertificateVerifier;
+
+  /**
    * Verify every transfer in the request against the trust base shipped with it.
    *
    * @param {ITransferTransactionVerificationRequest} request The batch to verify.
@@ -251,7 +265,7 @@ export abstract class TransferTransactionVerifier {
       const results: ITransferTransactionVerificationResult[] = [];
       for (const transfer of request.transfers) {
         const transaction = WorkerTransferTransaction.fromCBOR(transfer.bytes);
-        const result = await transaction.verify(trustBase, this.predicateVerifier);
+        const result = await transaction.verify(trustBase, this.predicateVerifier, this.unicityCertificateVerifier);
         results.push({ index: transfer.index, message: result.message, status: result.status });
       }
 

--- a/src/util/InclusionProofUtils.ts
+++ b/src/util/InclusionProofUtils.ts
@@ -1,4 +1,5 @@
 import { RootTrustBase } from '../api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../api/bft/verification/UnicityCertificateVerifier.js';
 import { InclusionProof } from '../api/InclusionProof.js';
 import { JsonRpcNetworkError } from '../api/json-rpc/JsonRpcNetworkError.js';
 import { StateId } from '../api/StateId.js';
@@ -156,6 +157,7 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
  * @param {StateTransitionClient} client Client used to fetch inclusion proofs.
  * @param {RootTrustBase} trustBase Root trust base used to verify the inclusion certificate.
  * @param {PredicateVerifierService} predicateVerifier Verifier used to check the transaction predicate.
+ * @param {UnicityCertificateVerifier} unicityCertificateVerifier Unicity certificate verifier.
  * @param {ITransaction} transaction Transaction whose inclusion is being awaited.
  * @param {AbortSignal} signal Abort signal that terminates polling. Defaults to a 10s timeout.
  * @param {number} interval Delay between polls in milliseconds. Defaults to 1000.
@@ -166,6 +168,7 @@ export async function waitInclusionProof(
   client: StateTransitionClient,
   trustBase: RootTrustBase,
   predicateVerifier: PredicateVerifierService,
+  unicityCertificateVerifier: UnicityCertificateVerifier,
   transaction: ITransaction,
   signal: AbortSignal = AbortSignal.timeout(10000),
   interval: number = 1000,
@@ -178,6 +181,7 @@ export async function waitInclusionProof(
     const verificationStatus = await InclusionProofVerificationRule.verify(
       trustBase,
       predicateVerifier,
+      unicityCertificateVerifier,
       inclusionProof,
       transactionHash,
       transaction.lockScript,

--- a/tests/e2e/InclusionProofDeadlineTest.ts
+++ b/tests/e2e/InclusionProofDeadlineTest.ts
@@ -1,10 +1,12 @@
 import { createE2EContext } from './E2EConfig.js';
+import { UnicityCertificateVerifier } from '../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../src/api/CertificationData.js';
 import { CertificationResponse } from '../../src/api/CertificationResponse.js';
 import { IAggregatorClient } from '../../src/api/IAggregatorClient.js';
 import { InclusionProofResponse } from '../../src/api/InclusionProofResponse.js';
 import { IRequestOptions } from '../../src/api/IRequestOptions.js';
 import { StateId } from '../../src/api/StateId.js';
+import { Secp256k1SignatureVerifier } from '../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../src/predicate/builtin/SignaturePredicate.js';
 import { PredicateVerifierService } from '../../src/predicate/verification/PredicateVerifierService.js';
@@ -49,6 +51,7 @@ class DeadlineDuringRequestClient implements IAggregatorClient {
 describe('E2E waitInclusionProof deadline', () => {
   const { aggregatorClient, trustBase } = createE2EContext();
   const predicateVerifier = PredicateVerifierService.create();
+  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
 
   let transaction: MintTransaction;
 
@@ -68,7 +71,15 @@ describe('E2E waitInclusionProof deadline', () => {
   const outcomeOf = async (client: StateTransitionClient, signal: AbortSignal, interval: number): Promise<string> => {
     let guard: ReturnType<typeof setTimeout> | undefined;
     const outcome = await Promise.race([
-      waitInclusionProof(client, trustBase, predicateVerifier, transaction, signal, interval).then(
+      waitInclusionProof(
+        client,
+        trustBase,
+        predicateVerifier,
+        unicityCertificateVerifier,
+        transaction,
+        signal,
+        interval,
+      ).then(
         () => 'resolved',
         (err: unknown) => (err instanceof Error ? err.name : String(err)),
       ),

--- a/tests/e2e/InclusionProofDeadlineTest.ts
+++ b/tests/e2e/InclusionProofDeadlineTest.ts
@@ -1,12 +1,10 @@
 import { createE2EContext } from './E2EConfig.js';
-import { UnicityCertificateVerifier } from '../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../src/api/CertificationData.js';
 import { CertificationResponse } from '../../src/api/CertificationResponse.js';
 import { IAggregatorClient } from '../../src/api/IAggregatorClient.js';
 import { InclusionProofResponse } from '../../src/api/InclusionProofResponse.js';
 import { IRequestOptions } from '../../src/api/IRequestOptions.js';
 import { StateId } from '../../src/api/StateId.js';
-import { Secp256k1SignatureVerifier } from '../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../src/predicate/builtin/SignaturePredicate.js';
 import { PredicateVerifierService } from '../../src/predicate/verification/PredicateVerifierService.js';
@@ -15,6 +13,7 @@ import { MintTransaction } from '../../src/transaction/MintTransaction.js';
 import { TokenSalt } from '../../src/transaction/TokenSalt.js';
 import { TokenType } from '../../src/transaction/TokenType.js';
 import { waitInclusionProof } from '../../src/util/InclusionProofUtils.js';
+import { createUnicityCertificateVerifier } from '../utils/UnicityCertificateVerifierFixture.js';
 
 /** How long a wait may run past its own deadline before it counts as unbounded. */
 const UNBOUNDED_AFTER_MS = 20000;
@@ -51,7 +50,7 @@ class DeadlineDuringRequestClient implements IAggregatorClient {
 describe('E2E waitInclusionProof deadline', () => {
   const { aggregatorClient, trustBase } = createE2EContext();
   const predicateVerifier = PredicateVerifierService.create();
-  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+  const unicityCertificateVerifier = createUnicityCertificateVerifier();
 
   let transaction: MintTransaction;
 

--- a/tests/examples/mint/ExampleTest.ts
+++ b/tests/examples/mint/ExampleTest.ts
@@ -1,8 +1,10 @@
 import config from './config.json' with { type: 'json' };
 import { AggregatorClient } from '../../../src/api/AggregatorClient.js';
 import { RootTrustBase } from '../../../src/api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../../src/api/CertificationData.js';
 import { NetworkId } from '../../../src/api/NetworkId.js';
+import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../../src/predicate/builtin/SignaturePredicate.js';
 import { PredicateVerifierService } from '../../../src/predicate/verification/PredicateVerifierService.js';
@@ -25,9 +27,11 @@ it('Token minting', async () => {
   const client = new StateTransitionClient(aggregatorClient);
 
   const predicateVerifier = PredicateVerifierService.create();
+  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
   const verificationContext = new VerificationContext(
     trustBase,
     predicateVerifier,
+    unicityCertificateVerifier,
     new MintJustificationVerifierService(),
     new TokenIssuanceVerifierService(false),
   );
@@ -50,7 +54,8 @@ it('Token minting', async () => {
     await mintTransaction.toCertifiedTransaction(
       trustBase,
       predicateVerifier,
-      await waitInclusionProof(client, trustBase, predicateVerifier, mintTransaction),
+      unicityCertificateVerifier,
+      await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, mintTransaction),
     ),
     verificationContext,
   );

--- a/tests/examples/mint/ExampleTest.ts
+++ b/tests/examples/mint/ExampleTest.ts
@@ -1,10 +1,8 @@
 import config from './config.json' with { type: 'json' };
 import { AggregatorClient } from '../../../src/api/AggregatorClient.js';
 import { RootTrustBase } from '../../../src/api/bft/RootTrustBase.js';
-import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../../src/api/CertificationData.js';
 import { NetworkId } from '../../../src/api/NetworkId.js';
-import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../../src/predicate/builtin/SignaturePredicate.js';
 import { PredicateVerifierService } from '../../../src/predicate/verification/PredicateVerifierService.js';
@@ -18,6 +16,7 @@ import { TokenIssuanceVerifierService } from '../../../src/transaction/verificat
 import { VerificationContext } from '../../../src/transaction/verification/VerificationContext.js';
 import { HexConverter } from '../../../src/util/HexConverter.js';
 import { waitInclusionProof } from '../../../src/util/InclusionProofUtils.js';
+import { createUnicityCertificateVerifier } from '../../utils/UnicityCertificateVerifierFixture.js';
 import trustBaseJson from '../trust-base.json' with { type: 'json' };
 
 it('Token minting', async () => {
@@ -27,7 +26,7 @@ it('Token minting', async () => {
   const client = new StateTransitionClient(aggregatorClient);
 
   const predicateVerifier = PredicateVerifierService.create();
-  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+  const unicityCertificateVerifier = createUnicityCertificateVerifier();
   const verificationContext = new VerificationContext(
     trustBase,
     predicateVerifier,

--- a/tests/examples/split/ExampleTest.ts
+++ b/tests/examples/split/ExampleTest.ts
@@ -2,9 +2,11 @@ import config from './config.json' with { type: 'json' };
 import { CustomPaymentData } from './CustomPaymentData.js';
 import { AggregatorClient } from '../../../src/api/AggregatorClient.js';
 import { RootTrustBase } from '../../../src/api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../../src/api/CertificationData.js';
 import { CertificationStatus } from '../../../src/api/CertificationResponse.js';
 import { NetworkId } from '../../../src/api/NetworkId.js';
+import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { Asset } from '../../../src/payment/asset/Asset.js';
 import { AssetId } from '../../../src/payment/asset/AssetId.js';
@@ -34,11 +36,13 @@ it('Token splitting', async () => {
   const client = new StateTransitionClient(aggregatorClient);
 
   const predicateVerifier = PredicateVerifierService.create();
+  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
   const mintJustificationVerifier = new MintJustificationVerifierService();
   mintJustificationVerifier.register(new SplitMintJustificationVerifier(CustomPaymentData.decode));
   const verificationContext = new VerificationContext(
     trustBase,
     predicateVerifier,
+    unicityCertificateVerifier,
     mintJustificationVerifier,
     new TokenIssuanceVerifierService(false),
   );
@@ -72,7 +76,8 @@ it('Token splitting', async () => {
     await mintTransaction.toCertifiedTransaction(
       trustBase,
       predicateVerifier,
-      await waitInclusionProof(client, trustBase, predicateVerifier, mintTransaction),
+      unicityCertificateVerifier,
+      await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, mintTransaction),
     ),
     verificationContext,
   );
@@ -118,7 +123,14 @@ it('Token splitting', async () => {
     await result.burn.transaction.toCertifiedTransaction(
       trustBase,
       predicateVerifier,
-      await waitInclusionProof(client, trustBase, predicateVerifier, result.burn.transaction),
+      unicityCertificateVerifier,
+      await waitInclusionProof(
+        client,
+        trustBase,
+        predicateVerifier,
+        unicityCertificateVerifier,
+        result.burn.transaction,
+      ),
     ),
     verificationContext,
   );
@@ -145,7 +157,8 @@ it('Token splitting', async () => {
       await mintTransaction.toCertifiedTransaction(
         trustBase,
         predicateVerifier,
-        await waitInclusionProof(client, trustBase, predicateVerifier, mintTransaction),
+        unicityCertificateVerifier,
+        await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, mintTransaction),
       ),
       verificationContext,
     );

--- a/tests/examples/split/ExampleTest.ts
+++ b/tests/examples/split/ExampleTest.ts
@@ -2,11 +2,9 @@ import config from './config.json' with { type: 'json' };
 import { CustomPaymentData } from './CustomPaymentData.js';
 import { AggregatorClient } from '../../../src/api/AggregatorClient.js';
 import { RootTrustBase } from '../../../src/api/bft/RootTrustBase.js';
-import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../../src/api/CertificationData.js';
 import { CertificationStatus } from '../../../src/api/CertificationResponse.js';
 import { NetworkId } from '../../../src/api/NetworkId.js';
-import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { Asset } from '../../../src/payment/asset/Asset.js';
 import { AssetId } from '../../../src/payment/asset/AssetId.js';
@@ -27,6 +25,7 @@ import { TokenIssuanceVerifierService } from '../../../src/transaction/verificat
 import { VerificationContext } from '../../../src/transaction/verification/VerificationContext.js';
 import { HexConverter } from '../../../src/util/HexConverter.js';
 import { waitInclusionProof } from '../../../src/util/InclusionProofUtils.js';
+import { createUnicityCertificateVerifier } from '../../utils/UnicityCertificateVerifierFixture.js';
 import trustBaseJson from '../trust-base.json' with { type: 'json' };
 
 it('Token splitting', async () => {
@@ -36,7 +35,7 @@ it('Token splitting', async () => {
   const client = new StateTransitionClient(aggregatorClient);
 
   const predicateVerifier = PredicateVerifierService.create();
-  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+  const unicityCertificateVerifier = createUnicityCertificateVerifier();
   const mintJustificationVerifier = new MintJustificationVerifierService();
   mintJustificationVerifier.register(new SplitMintJustificationVerifier(CustomPaymentData.decode));
   const verificationContext = new VerificationContext(

--- a/tests/examples/transfer/ExampleTest.ts
+++ b/tests/examples/transfer/ExampleTest.ts
@@ -1,9 +1,11 @@
 import config from './config.json' with { type: 'json' };
 import { AggregatorClient } from '../../../src/api/AggregatorClient.js';
 import { RootTrustBase } from '../../../src/api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../../src/api/CertificationData.js';
 import { CertificationStatus } from '../../../src/api/CertificationResponse.js';
 import { NetworkId } from '../../../src/api/NetworkId.js';
+import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../../src/predicate/builtin/SignaturePredicate.js';
 import { SignaturePredicateUnlockScript } from '../../../src/predicate/builtin/SignaturePredicateUnlockScript.js';
@@ -26,9 +28,11 @@ import trustBaseJson from '../trust-base.json' with { type: 'json' };
 
 async function receiveToken(client: StateTransitionClient, trustBase: RootTrustBase): Promise<string> {
   const predicateVerifier = PredicateVerifierService.create();
+  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
   const verificationContext = new VerificationContext(
     trustBase,
     predicateVerifier,
+    unicityCertificateVerifier,
     new MintJustificationVerifierService(),
     new TokenIssuanceVerifierService(false),
   );
@@ -51,7 +55,8 @@ async function receiveToken(client: StateTransitionClient, trustBase: RootTrustB
     await mintTransaction.toCertifiedTransaction(
       trustBase,
       predicateVerifier,
-      await waitInclusionProof(client, trustBase, predicateVerifier, mintTransaction),
+      unicityCertificateVerifier,
+      await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, mintTransaction),
     ),
     verificationContext,
   );
@@ -64,9 +69,11 @@ it('Token transfer', async () => {
   const trustBase = RootTrustBase.fromJSON(trustBaseJson);
   const client = new StateTransitionClient(aggregatorClient);
   const predicateVerifier = PredicateVerifierService.create();
+  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
   const verificationContext = new VerificationContext(
     trustBase,
     predicateVerifier,
+    unicityCertificateVerifier,
     new MintJustificationVerifierService(),
     new TokenIssuanceVerifierService(false),
   );
@@ -106,7 +113,8 @@ it('Token transfer', async () => {
     await transferTransaction.toCertifiedTransaction(
       trustBase,
       predicateVerifier,
-      await waitInclusionProof(client, trustBase, predicateVerifier, transferTransaction),
+      unicityCertificateVerifier,
+      await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, transferTransaction),
     ),
     verificationContext,
   );

--- a/tests/examples/transfer/ExampleTest.ts
+++ b/tests/examples/transfer/ExampleTest.ts
@@ -1,11 +1,9 @@
 import config from './config.json' with { type: 'json' };
 import { AggregatorClient } from '../../../src/api/AggregatorClient.js';
 import { RootTrustBase } from '../../../src/api/bft/RootTrustBase.js';
-import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../../src/api/CertificationData.js';
 import { CertificationStatus } from '../../../src/api/CertificationResponse.js';
 import { NetworkId } from '../../../src/api/NetworkId.js';
-import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../../src/predicate/builtin/SignaturePredicate.js';
 import { SignaturePredicateUnlockScript } from '../../../src/predicate/builtin/SignaturePredicateUnlockScript.js';
@@ -24,11 +22,12 @@ import { VerificationContext } from '../../../src/transaction/verification/Verif
 import { HexConverter } from '../../../src/util/HexConverter.js';
 import { waitInclusionProof } from '../../../src/util/InclusionProofUtils.js';
 import { VerificationStatus } from '../../../src/verification/VerificationStatus.js';
+import { createUnicityCertificateVerifier } from '../../utils/UnicityCertificateVerifierFixture.js';
 import trustBaseJson from '../trust-base.json' with { type: 'json' };
 
 async function receiveToken(client: StateTransitionClient, trustBase: RootTrustBase): Promise<string> {
   const predicateVerifier = PredicateVerifierService.create();
-  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+  const unicityCertificateVerifier = createUnicityCertificateVerifier();
   const verificationContext = new VerificationContext(
     trustBase,
     predicateVerifier,
@@ -69,7 +68,7 @@ it('Token transfer', async () => {
   const trustBase = RootTrustBase.fromJSON(trustBaseJson);
   const client = new StateTransitionClient(aggregatorClient);
   const predicateVerifier = PredicateVerifierService.create();
-  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+  const unicityCertificateVerifier = createUnicityCertificateVerifier();
   const verificationContext = new VerificationContext(
     trustBase,
     predicateVerifier,

--- a/tests/functional/ExampleTransferTransactionVerifierWorker.ts
+++ b/tests/functional/ExampleTransferTransactionVerifierWorker.ts
@@ -1,3 +1,5 @@
+import { UnicityCertificateVerifier } from '../../src/api/bft/verification/UnicityCertificateVerifier.js';
+import { Secp256k1SignatureVerifier } from '../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { PredicateVerifierService } from '../../src/predicate/verification/PredicateVerifierService.js';
 import { NodeTransferTransactionVerifierWorker } from '../../src/transaction/verification/worker/NodeTransferTransactionVerifierWorker.js';
 
@@ -12,10 +14,15 @@ import { NodeTransferTransactionVerifierWorker } from '../../src/transaction/ver
  * serves as the worker body for {@link FakeWorker}-based tests.
  */
 export class ExampleTransferTransactionVerifierWorker extends NodeTransferTransactionVerifierWorker {
+  private readonly certificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
   private readonly verifier = PredicateVerifierService.create();
 
   protected get predicateVerifier(): PredicateVerifierService {
     return this.verifier;
+  }
+
+  protected get unicityCertificateVerifier(): UnicityCertificateVerifier {
+    return this.certificateVerifier;
   }
 }
 

--- a/tests/functional/ExampleTransferTransactionVerifierWorker.ts
+++ b/tests/functional/ExampleTransferTransactionVerifierWorker.ts
@@ -1,7 +1,7 @@
 import { UnicityCertificateVerifier } from '../../src/api/bft/verification/UnicityCertificateVerifier.js';
-import { Secp256k1SignatureVerifier } from '../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { PredicateVerifierService } from '../../src/predicate/verification/PredicateVerifierService.js';
 import { NodeTransferTransactionVerifierWorker } from '../../src/transaction/verification/worker/NodeTransferTransactionVerifierWorker.js';
+import { createUnicityCertificateVerifier } from '../utils/UnicityCertificateVerifierFixture.js';
 
 /**
  * Example Node.js worker entry script: verifies with the built-in predicate verifier,
@@ -14,7 +14,7 @@ import { NodeTransferTransactionVerifierWorker } from '../../src/transaction/ver
  * serves as the worker body for {@link FakeWorker}-based tests.
  */
 export class ExampleTransferTransactionVerifierWorker extends NodeTransferTransactionVerifierWorker {
-  private readonly certificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+  private readonly certificateVerifier = createUnicityCertificateVerifier();
   private readonly verifier = PredicateVerifierService.create();
 
   protected get predicateVerifier(): PredicateVerifierService {

--- a/tests/functional/WorkerTokenVerifierTest.ts
+++ b/tests/functional/WorkerTokenVerifierTest.ts
@@ -5,7 +5,6 @@ import { Worker } from 'node:worker_threads';
 import { ExampleTransferTransactionVerifierWorker } from './ExampleTransferTransactionVerifierWorker.js';
 import { TestAggregatorClient } from './TestAggregatorClient.js';
 import { UnicityCertificateVerifier } from '../../src/api/bft/verification/UnicityCertificateVerifier.js';
-import { Secp256k1SignatureVerifier } from '../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../src/predicate/builtin/SignaturePredicate.js';
 import { PredicateVerifierService } from '../../src/predicate/verification/PredicateVerifierService.js';
@@ -26,6 +25,7 @@ import {
 } from '../../src/transaction/verification/worker/WorkerTokenVerifier.js';
 import { VerificationStatus } from '../../src/verification/VerificationStatus.js';
 import { mintToken, transferToken } from '../utils/TokenUtils.js';
+import { createUnicityCertificateVerifier } from '../utils/UnicityCertificateVerifierFixture.js';
 
 type Responder = (request: ITransferTransactionVerificationRequest) => Promise<TransferTransactionVerificationResponse>;
 
@@ -97,7 +97,7 @@ describe('WorkerTokenVerifier', () => {
     new VerificationContext(
       trustBase,
       PredicateVerifierService.create(),
-      new UnicityCertificateVerifier(new Secp256k1SignatureVerifier()),
+      createUnicityCertificateVerifier(),
       new MintJustificationVerifierService(),
       new TokenIssuanceVerifierService(false),
     );
@@ -204,7 +204,7 @@ describe('WorkerTokenVerifier', () => {
       }
 
       protected get unicityCertificateVerifier(): UnicityCertificateVerifier {
-        return new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+        return createUnicityCertificateVerifier();
       }
     }
 

--- a/tests/functional/WorkerTokenVerifierTest.ts
+++ b/tests/functional/WorkerTokenVerifierTest.ts
@@ -4,6 +4,8 @@ import { Worker } from 'node:worker_threads';
 
 import { ExampleTransferTransactionVerifierWorker } from './ExampleTransferTransactionVerifierWorker.js';
 import { TestAggregatorClient } from './TestAggregatorClient.js';
+import { UnicityCertificateVerifier } from '../../src/api/bft/verification/UnicityCertificateVerifier.js';
+import { Secp256k1SignatureVerifier } from '../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../src/predicate/builtin/SignaturePredicate.js';
 import { PredicateVerifierService } from '../../src/predicate/verification/PredicateVerifierService.js';
@@ -95,6 +97,7 @@ describe('WorkerTokenVerifier', () => {
     new VerificationContext(
       trustBase,
       PredicateVerifierService.create(),
+      new UnicityCertificateVerifier(new Secp256k1SignatureVerifier()),
       new MintJustificationVerifierService(),
       new TokenIssuanceVerifierService(false),
     );
@@ -198,6 +201,10 @@ describe('WorkerTokenVerifier', () => {
     class CustomTransferTransactionVerifier extends TransferTransactionVerifier {
       protected get predicateVerifier(): PredicateVerifierService {
         return customPredicateVerifier;
+      }
+
+      protected get unicityCertificateVerifier(): UnicityCertificateVerifier {
+        return new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
       }
     }
 

--- a/tests/functional/payment/SplitBuilderTest.ts
+++ b/tests/functional/payment/SplitBuilderTest.ts
@@ -1,9 +1,7 @@
 import { TestPaymentData } from './TestPaymentData.js';
-import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../../src/api/CertificationData.js';
 import { CertificationStatus } from '../../../src/api/CertificationResponse.js';
 import { NetworkId } from '../../../src/api/NetworkId.js';
-import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { Asset } from '../../../src/payment/asset/Asset.js';
 import { AssetId } from '../../../src/payment/asset/AssetId.js';
@@ -28,6 +26,7 @@ import { VerificationContext } from '../../../src/transaction/verification/Verif
 import { HexConverter } from '../../../src/util/HexConverter.js';
 import { waitInclusionProof } from '../../../src/util/InclusionProofUtils.js';
 import { VerificationStatus } from '../../../src/verification/VerificationStatus.js';
+import { createUnicityCertificateVerifier } from '../../utils/UnicityCertificateVerifierFixture.js';
 import { TestAggregatorClient } from '../TestAggregatorClient.js';
 
 describe('SplitBuilder Functional Test', () => {
@@ -36,7 +35,7 @@ describe('SplitBuilder Functional Test', () => {
     const trustBase = aggregatorClient.rootTrustBase;
     const client = new StateTransitionClient(aggregatorClient);
     const predicateVerifier = PredicateVerifierService.create();
-    const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+    const unicityCertificateVerifier = createUnicityCertificateVerifier();
     const mintJustificationVerifier = new MintJustificationVerifierService();
     mintJustificationVerifier.register(new SplitMintJustificationVerifier(TestPaymentData.decode));
     const verificationContext = new VerificationContext(
@@ -242,7 +241,7 @@ describe('SplitBuilder Functional Test', () => {
     const trustBase = aggregatorClient.rootTrustBase;
     const client = new StateTransitionClient(aggregatorClient);
     const predicateVerifier = PredicateVerifierService.create();
-    const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+    const unicityCertificateVerifier = createUnicityCertificateVerifier();
     const mintJustificationVerifier = new MintJustificationVerifierService();
     mintJustificationVerifier.register(new SplitMintJustificationVerifier(TestPaymentData.decode));
     const verificationContext = new VerificationContext(

--- a/tests/functional/payment/SplitBuilderTest.ts
+++ b/tests/functional/payment/SplitBuilderTest.ts
@@ -1,7 +1,9 @@
 import { TestPaymentData } from './TestPaymentData.js';
+import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../../src/api/CertificationData.js';
 import { CertificationStatus } from '../../../src/api/CertificationResponse.js';
 import { NetworkId } from '../../../src/api/NetworkId.js';
+import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { Asset } from '../../../src/payment/asset/Asset.js';
 import { AssetId } from '../../../src/payment/asset/AssetId.js';
@@ -34,11 +36,13 @@ describe('SplitBuilder Functional Test', () => {
     const trustBase = aggregatorClient.rootTrustBase;
     const client = new StateTransitionClient(aggregatorClient);
     const predicateVerifier = PredicateVerifierService.create();
+    const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
     const mintJustificationVerifier = new MintJustificationVerifierService();
     mintJustificationVerifier.register(new SplitMintJustificationVerifier(TestPaymentData.decode));
     const verificationContext = new VerificationContext(
       trustBase,
       predicateVerifier,
+      unicityCertificateVerifier,
       mintJustificationVerifier,
       new TokenIssuanceVerifierService(false),
     );
@@ -63,7 +67,8 @@ describe('SplitBuilder Functional Test', () => {
       await mintTransaction.toCertifiedTransaction(
         trustBase,
         predicateVerifier,
-        await waitInclusionProof(client, trustBase, predicateVerifier, mintTransaction),
+        unicityCertificateVerifier,
+        await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, mintTransaction),
       ),
       verificationContext,
     );
@@ -115,7 +120,14 @@ describe('SplitBuilder Functional Test', () => {
       await result.burn.transaction.toCertifiedTransaction(
         trustBase,
         predicateVerifier,
-        await waitInclusionProof(client, trustBase, predicateVerifier, result.burn.transaction),
+        unicityCertificateVerifier,
+        await waitInclusionProof(
+          client,
+          trustBase,
+          predicateVerifier,
+          unicityCertificateVerifier,
+          result.burn.transaction,
+        ),
       ),
       verificationContext,
     );
@@ -140,7 +152,8 @@ describe('SplitBuilder Functional Test', () => {
         await mintTransaction.toCertifiedTransaction(
           trustBase,
           predicateVerifier,
-          await waitInclusionProof(client, trustBase, predicateVerifier, mintTransaction),
+          unicityCertificateVerifier,
+          await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, mintTransaction),
         ),
         verificationContext,
       );
@@ -174,7 +187,14 @@ describe('SplitBuilder Functional Test', () => {
       await secondSplit.burn.transaction.toCertifiedTransaction(
         trustBase,
         predicateVerifier,
-        await waitInclusionProof(client, trustBase, predicateVerifier, secondSplit.burn.transaction),
+        unicityCertificateVerifier,
+        await waitInclusionProof(
+          client,
+          trustBase,
+          predicateVerifier,
+          unicityCertificateVerifier,
+          secondSplit.burn.transaction,
+        ),
       ),
       verificationContext,
     );
@@ -198,7 +218,14 @@ describe('SplitBuilder Functional Test', () => {
       await secondMintTransaction.toCertifiedTransaction(
         trustBase,
         predicateVerifier,
-        await waitInclusionProof(client, trustBase, predicateVerifier, secondMintTransaction),
+        unicityCertificateVerifier,
+        await waitInclusionProof(
+          client,
+          trustBase,
+          predicateVerifier,
+          unicityCertificateVerifier,
+          secondMintTransaction,
+        ),
       ),
       verificationContext,
     );
@@ -215,11 +242,13 @@ describe('SplitBuilder Functional Test', () => {
     const trustBase = aggregatorClient.rootTrustBase;
     const client = new StateTransitionClient(aggregatorClient);
     const predicateVerifier = PredicateVerifierService.create();
+    const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
     const mintJustificationVerifier = new MintJustificationVerifierService();
     mintJustificationVerifier.register(new SplitMintJustificationVerifier(TestPaymentData.decode));
     const verificationContext = new VerificationContext(
       trustBase,
       predicateVerifier,
+      unicityCertificateVerifier,
       mintJustificationVerifier,
       new TokenIssuanceVerifierService(false),
     );
@@ -239,7 +268,8 @@ describe('SplitBuilder Functional Test', () => {
       await mintTransaction.toCertifiedTransaction(
         trustBase,
         predicateVerifier,
-        await waitInclusionProof(client, trustBase, predicateVerifier, mintTransaction),
+        unicityCertificateVerifier,
+        await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, mintTransaction),
       ),
       verificationContext,
     );

--- a/tests/functional/payment/SplitInflationExploitTest.ts
+++ b/tests/functional/payment/SplitInflationExploitTest.ts
@@ -1,12 +1,10 @@
 import { TestPaymentData } from './TestPaymentData.js';
-import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../../src/api/CertificationData.js';
 import { CertificationStatus } from '../../../src/api/CertificationResponse.js';
 import { NetworkId } from '../../../src/api/NetworkId.js';
 import { DataHasher } from '../../../src/crypto/hash/DataHasher.js';
 import { DataHasherFactory } from '../../../src/crypto/hash/DataHasherFactory.js';
 import { HashAlgorithm } from '../../../src/crypto/hash/HashAlgorithm.js';
-import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { Asset } from '../../../src/payment/asset/Asset.js';
 import { AssetId } from '../../../src/payment/asset/AssetId.js';
@@ -34,6 +32,7 @@ import { TokenIssuanceVerifierService } from '../../../src/transaction/verificat
 import { VerificationContext } from '../../../src/transaction/verification/VerificationContext.js';
 import { waitInclusionProof } from '../../../src/util/InclusionProofUtils.js';
 import { VerificationError } from '../../../src/verification/VerificationError.js';
+import { createUnicityCertificateVerifier } from '../../utils/UnicityCertificateVerifierFixture.js';
 import { TestAggregatorClient } from '../TestAggregatorClient.js';
 
 /**
@@ -89,7 +88,7 @@ describe('Split inflation exploit', () => {
     const trustBase = aggregatorClient.rootTrustBase;
     const client = new StateTransitionClient(aggregatorClient);
     const predicateVerifier = PredicateVerifierService.create();
-    const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+    const unicityCertificateVerifier = createUnicityCertificateVerifier();
     const mintJustificationVerifier = new MintJustificationVerifierService();
     mintJustificationVerifier.register(new SplitMintJustificationVerifier(TestPaymentData.decode));
     const verificationContext = new VerificationContext(

--- a/tests/functional/payment/SplitInflationExploitTest.ts
+++ b/tests/functional/payment/SplitInflationExploitTest.ts
@@ -1,10 +1,12 @@
 import { TestPaymentData } from './TestPaymentData.js';
+import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../../src/api/CertificationData.js';
 import { CertificationStatus } from '../../../src/api/CertificationResponse.js';
 import { NetworkId } from '../../../src/api/NetworkId.js';
 import { DataHasher } from '../../../src/crypto/hash/DataHasher.js';
 import { DataHasherFactory } from '../../../src/crypto/hash/DataHasherFactory.js';
 import { HashAlgorithm } from '../../../src/crypto/hash/HashAlgorithm.js';
+import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { Asset } from '../../../src/payment/asset/Asset.js';
 import { AssetId } from '../../../src/payment/asset/AssetId.js';
@@ -87,11 +89,13 @@ describe('Split inflation exploit', () => {
     const trustBase = aggregatorClient.rootTrustBase;
     const client = new StateTransitionClient(aggregatorClient);
     const predicateVerifier = PredicateVerifierService.create();
+    const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
     const mintJustificationVerifier = new MintJustificationVerifierService();
     mintJustificationVerifier.register(new SplitMintJustificationVerifier(TestPaymentData.decode));
     const verificationContext = new VerificationContext(
       trustBase,
       predicateVerifier,
+      unicityCertificateVerifier,
       mintJustificationVerifier,
       new TokenIssuanceVerifierService(false),
     );
@@ -118,7 +122,8 @@ describe('Split inflation exploit', () => {
       await sourceMint.toCertifiedTransaction(
         trustBase,
         predicateVerifier,
-        await waitInclusionProof(client, trustBase, predicateVerifier, sourceMint),
+        unicityCertificateVerifier,
+        await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, sourceMint),
       ),
       verificationContext,
     );
@@ -140,7 +145,8 @@ describe('Split inflation exploit', () => {
       await handover.toCertifiedTransaction(
         trustBase,
         predicateVerifier,
-        await waitInclusionProof(client, trustBase, predicateVerifier, handover),
+        unicityCertificateVerifier,
+        await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, handover),
       ),
       verificationContext,
     );
@@ -175,7 +181,8 @@ describe('Split inflation exploit', () => {
       await burnTransaction.toCertifiedTransaction(
         trustBase,
         predicateVerifier,
-        await waitInclusionProof(client, trustBase, predicateVerifier, burnTransaction),
+        unicityCertificateVerifier,
+        await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, burnTransaction),
       ),
       verificationContext,
     );
@@ -199,7 +206,8 @@ describe('Split inflation exploit', () => {
       const certified = await mintTransaction.toCertifiedTransaction(
         trustBase,
         predicateVerifier,
-        await waitInclusionProof(client, trustBase, predicateVerifier, mintTransaction),
+        unicityCertificateVerifier,
+        await waitInclusionProof(client, trustBase, predicateVerifier, unicityCertificateVerifier, mintTransaction),
       );
 
       // Conservation: a 500-value token cannot back a 500-value output when the sibling total is 1000.

--- a/tests/unit/api/InclusionProofTest.ts
+++ b/tests/unit/api/InclusionProofTest.ts
@@ -10,7 +10,6 @@ import { DataHash } from '../../../src/crypto/hash/DataHash.js';
 import { DataHasherFactory } from '../../../src/crypto/hash/DataHasherFactory.js';
 import { HashAlgorithm } from '../../../src/crypto/hash/HashAlgorithm.js';
 import { NodeDataHasher } from '../../../src/crypto/hash/NodeDataHasher.js';
-import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../../src/predicate/builtin/SignaturePredicate.js';
 import { EncodedPredicate } from '../../../src/predicate/EncodedPredicate.js';
@@ -25,6 +24,7 @@ import {
 import { HexConverter } from '../../../src/util/HexConverter.js';
 import { createRootTrustBase } from '../../utils/RootTrustBaseFixture.js';
 import { createUnicityCertificate } from '../../utils/UnicityCertificateFixture.js';
+import { createUnicityCertificateVerifier } from '../../utils/UnicityCertificateVerifierFixture.js';
 
 describe('InclusionProof', () => {
   const signingService = new SigningService(
@@ -54,7 +54,7 @@ describe('InclusionProof', () => {
     unicityCertificate = await createUnicityCertificate(root.hash, signingService);
     trustBase = createRootTrustBase(signingService.publicKey);
     predicateVerifier = PredicateVerifierService.create();
-    unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+    unicityCertificateVerifier = createUnicityCertificateVerifier();
   });
 
   it('should encode and decode cbor', () => {

--- a/tests/unit/api/InclusionProofTest.ts
+++ b/tests/unit/api/InclusionProofTest.ts
@@ -1,5 +1,6 @@
 import { RootTrustBase } from '../../../src/api/bft/RootTrustBase.js';
 import { UnicityCertificate } from '../../../src/api/bft/UnicityCertificate.js';
+import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationData } from '../../../src/api/CertificationData.js';
 import { InclusionCertificate } from '../../../src/api/InclusionCertificate.js';
 import { InclusionProof } from '../../../src/api/InclusionProof.js';
@@ -9,6 +10,7 @@ import { DataHash } from '../../../src/crypto/hash/DataHash.js';
 import { DataHasherFactory } from '../../../src/crypto/hash/DataHasherFactory.js';
 import { HashAlgorithm } from '../../../src/crypto/hash/HashAlgorithm.js';
 import { NodeDataHasher } from '../../../src/crypto/hash/NodeDataHasher.js';
+import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../../src/predicate/builtin/SignaturePredicate.js';
 import { EncodedPredicate } from '../../../src/predicate/EncodedPredicate.js';
@@ -30,6 +32,7 @@ describe('InclusionProof', () => {
   );
 
   let predicateVerifier: PredicateVerifierService;
+  let unicityCertificateVerifier: UnicityCertificateVerifier;
   let transaction: MintTransaction;
   let certificationData: CertificationData;
   let inclusionCertificate: InclusionCertificate;
@@ -51,6 +54,7 @@ describe('InclusionProof', () => {
     unicityCertificate = await createUnicityCertificate(root.hash, signingService);
     trustBase = createRootTrustBase(signingService.publicKey);
     predicateVerifier = PredicateVerifierService.create();
+    unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
   });
 
   it('should encode and decode cbor', () => {
@@ -73,6 +77,7 @@ describe('InclusionProof', () => {
       InclusionProofVerificationRule.verify(
         trustBase,
         predicateVerifier,
+        unicityCertificateVerifier,
         new InclusionProof(certificationData, inclusionCertificate, unicityCertificate),
         transactionHash,
         transaction.lockScript,
@@ -84,6 +89,7 @@ describe('InclusionProof', () => {
       InclusionProofVerificationRule.verify(
         trustBase,
         predicateVerifier,
+        unicityCertificateVerifier,
         new InclusionProof(certificationData, null, unicityCertificate),
         transactionHash,
         transaction.lockScript,
@@ -117,6 +123,7 @@ describe('InclusionProof', () => {
       InclusionProofVerificationRule.verify(
         trustBase,
         predicateVerifier,
+        unicityCertificateVerifier,
         invalidTransactionHashInclusionProof,
         await transaction.calculateTransactionHash(),
         transaction.lockScript,
@@ -147,6 +154,7 @@ describe('InclusionProof', () => {
       InclusionProofVerificationRule.verify(
         trustBase,
         predicateVerifier,
+        unicityCertificateVerifier,
         inclusionProof,
         await transaction.calculateTransactionHash(),
         transaction.lockScript,
@@ -162,6 +170,7 @@ describe('InclusionProof', () => {
       InclusionProofVerificationRule.verify(
         createRootTrustBase(HexConverter.decode('0000000000000000000000000000000000000000000000000000000000000001')),
         predicateVerifier,
+        unicityCertificateVerifier,
         inclusionProof,
         await transaction.calculateTransactionHash(),
         transaction.lockScript,

--- a/tests/unit/api/bft/UnicitySealQuorumSignaturesVerificationRuleTest.ts
+++ b/tests/unit/api/bft/UnicitySealQuorumSignaturesVerificationRuleTest.ts
@@ -1,6 +1,7 @@
 import { UnicitySeal } from '../../../../src/api/bft/UnicitySeal.js';
 import { UnicitySealQuorumSignaturesVerificationRule } from '../../../../src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.js';
 import { NetworkId } from '../../../../src/api/NetworkId.js';
+import { Secp256k1SignatureVerifier } from '../../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../../src/crypto/secp256k1/SigningService.js';
 import { VerificationStatus } from '../../../../src/verification/VerificationStatus.js';
 import { createRootTrustBase } from '../../../utils/RootTrustBaseFixture.js';
@@ -20,25 +21,25 @@ describe('UnicitySealQuorumSignaturesVerificationRule', () => {
   const rootNode = signingServiceFrom(0x01);
   const impostor = signingServiceFrom(0x02);
 
+  let signatureVerifier: Secp256k1SignatureVerifier;
   let verifySpy: jest.SpyInstance;
 
   beforeEach(() => {
-    verifySpy = jest.spyOn(SigningService, 'verifyWithPublicKey');
-  });
-
-  afterEach(() => {
-    verifySpy.mockRestore();
+    // A fresh verifier per test: the memo is keyed on the verifier instance, so
+    // this isolates each test from the others' cached verdicts.
+    signatureVerifier = new Secp256k1SignatureVerifier();
+    verifySpy = jest.spyOn(signatureVerifier, 'verify');
   });
 
   it('verifies a quorum seal, then serves the repeat from the memo', async () => {
     const trustBase = createRootTrustBase(rootNode.publicKey);
     const seal = await sealSignedBy(rootNode);
 
-    const first = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, seal);
+    const first = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal);
     expect(first.status).toEqual(VerificationStatus.OK);
     expect(verifySpy).toHaveBeenCalledTimes(1);
 
-    const second = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, seal);
+    const second = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal);
     expect(second.status).toEqual(VerificationStatus.OK);
     expect(verifySpy).toHaveBeenCalledTimes(1);
   });
@@ -56,41 +57,63 @@ describe('UnicitySealQuorumSignaturesVerificationRule', () => {
     // The trap: identical bodies, hence identical signature-excluding hashes.
     expect((await forged.calculateHash()).toString()).toEqual((await genuine.calculateHash()).toString());
 
-    expect((await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, genuine)).status).toEqual(
-      VerificationStatus.OK,
-    );
+    expect(
+      (await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, genuine)).status,
+    ).toEqual(VerificationStatus.OK);
 
-    const result = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, forged);
+    const result = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, forged);
     expect(result.status).toEqual(VerificationStatus.FAIL);
   });
 
-  it('does not memoise across trust bases, since the outcome depends on the root nodes', async () => {
+  // The trust base is keyed by content, not identity: `_rootNodes` is an
+  // exposed Map and `readonly` stops only reassignment, so an in-place edit of
+  // the root keys must invalidate the memo rather than keep hitting a verdict
+  // computed under the old ones.
+  it('re-verifies after the trust base is mutated in place', async () => {
+    const trustBase = createRootTrustBase(rootNode.publicKey);
     const seal = await sealSignedBy(rootNode);
 
-    await UnicitySealQuorumSignaturesVerificationRule.verify(createRootTrustBase(rootNode.publicKey), seal);
+    expect(
+      (await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal)).status,
+    ).toEqual(VerificationStatus.OK);
     expect(verifySpy).toHaveBeenCalledTimes(1);
 
-    // A different trust base instance must re-verify rather than inherit the memo.
-    const other = await UnicitySealQuorumSignaturesVerificationRule.verify(
-      createRootTrustBase(rootNode.publicKey),
-      seal,
-    );
-    expect(other.status).toEqual(VerificationStatus.OK);
+    // Swap the root node's key for one that did not sign this seal, mutating
+    // the exposed Map in place exactly as an application could.
+    trustBase._rootNodes.set('NODE', createRootTrustBase(impostor.publicKey)._rootNodes.get('NODE')!);
+
+    const result = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal);
+    expect(result.status).toEqual(VerificationStatus.FAIL);
     expect(verifySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not memoise across signature verifiers, which need not agree', async () => {
+    const trustBase = createRootTrustBase(rootNode.publicKey);
+    const seal = await sealSignedBy(rootNode);
+
+    await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal);
+    expect(verifySpy).toHaveBeenCalledTimes(1);
+
+    const other = new Secp256k1SignatureVerifier();
+    const otherSpy = jest.spyOn(other, 'verify');
+    const result = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, other, seal);
+
+    expect(result.status).toEqual(VerificationStatus.OK);
+    expect(otherSpy).toHaveBeenCalledTimes(1);
   });
 
   it('does not memoise a seal that fails to reach quorum', async () => {
     const trustBase = createRootTrustBase(rootNode.publicKey);
     const seal = await sealSignedBy(impostor);
 
-    expect((await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, seal)).status).toEqual(
-      VerificationStatus.FAIL,
-    );
+    expect(
+      (await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal)).status,
+    ).toEqual(VerificationStatus.FAIL);
     expect(verifySpy).toHaveBeenCalledTimes(1);
 
-    expect((await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, seal)).status).toEqual(
-      VerificationStatus.FAIL,
-    );
+    expect(
+      (await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal)).status,
+    ).toEqual(VerificationStatus.FAIL);
     expect(verifySpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/api/bft/UnicitySealQuorumSignaturesVerificationRuleTest.ts
+++ b/tests/unit/api/bft/UnicitySealQuorumSignaturesVerificationRuleTest.ts
@@ -1,0 +1,96 @@
+import { UnicitySeal } from '../../../../src/api/bft/UnicitySeal.js';
+import { UnicitySealQuorumSignaturesVerificationRule } from '../../../../src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.js';
+import { NetworkId } from '../../../../src/api/NetworkId.js';
+import { SigningService } from '../../../../src/crypto/secp256k1/SigningService.js';
+import { VerificationStatus } from '../../../../src/verification/VerificationStatus.js';
+import { createRootTrustBase } from '../../../utils/RootTrustBaseFixture.js';
+
+/** Seal body shared by every seal built here, so their content hashes match. */
+const SEAL_CONTENT_HASH = new Uint8Array(32).fill(0x11);
+
+function signingServiceFrom(fill: number): SigningService {
+  return new SigningService(new Uint8Array(32).fill(fill));
+}
+
+function sealSignedBy(signingService: SigningService): Promise<UnicitySeal> {
+  return UnicitySeal.create(NetworkId.LOCAL, 0n, 0n, 0n, null, SEAL_CONTENT_HASH, new Map([['NODE', signingService]]));
+}
+
+describe('UnicitySealQuorumSignaturesVerificationRule', () => {
+  const rootNode = signingServiceFrom(0x01);
+  const impostor = signingServiceFrom(0x02);
+
+  let verifySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    verifySpy = jest.spyOn(SigningService, 'verifyWithPublicKey');
+  });
+
+  afterEach(() => {
+    verifySpy.mockRestore();
+  });
+
+  it('verifies a quorum seal, then serves the repeat from the memo', async () => {
+    const trustBase = createRootTrustBase(rootNode.publicKey);
+    const seal = await sealSignedBy(rootNode);
+
+    const first = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, seal);
+    expect(first.status).toEqual(VerificationStatus.OK);
+    expect(verifySpy).toHaveBeenCalledTimes(1);
+
+    const second = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, seal);
+    expect(second.status).toEqual(VerificationStatus.OK);
+    expect(verifySpy).toHaveBeenCalledTimes(1);
+  });
+
+  // The memo must key on the seal's COMPLETE encoding, not on calculateHash():
+  // that hash deliberately excludes the signatures (it is what the root nodes
+  // sign), so two seals with the same body but different signatures share it.
+  // Keyed on it, this forged seal would be served a cached OK and its bogus
+  // signatures would never be checked.
+  it('rejects a seal whose signatures were replaced, even after the genuine one was memoised', async () => {
+    const trustBase = createRootTrustBase(rootNode.publicKey);
+    const genuine = await sealSignedBy(rootNode);
+    const forged = await sealSignedBy(impostor);
+
+    // The trap: identical bodies, hence identical signature-excluding hashes.
+    expect((await forged.calculateHash()).toString()).toEqual((await genuine.calculateHash()).toString());
+
+    expect((await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, genuine)).status).toEqual(
+      VerificationStatus.OK,
+    );
+
+    const result = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, forged);
+    expect(result.status).toEqual(VerificationStatus.FAIL);
+  });
+
+  it('does not memoise across trust bases, since the outcome depends on the root nodes', async () => {
+    const seal = await sealSignedBy(rootNode);
+
+    await UnicitySealQuorumSignaturesVerificationRule.verify(createRootTrustBase(rootNode.publicKey), seal);
+    expect(verifySpy).toHaveBeenCalledTimes(1);
+
+    // A different trust base instance must re-verify rather than inherit the memo.
+    const other = await UnicitySealQuorumSignaturesVerificationRule.verify(
+      createRootTrustBase(rootNode.publicKey),
+      seal,
+    );
+    expect(other.status).toEqual(VerificationStatus.OK);
+    expect(verifySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not memoise a seal that fails to reach quorum', async () => {
+    const trustBase = createRootTrustBase(rootNode.publicKey);
+    const seal = await sealSignedBy(impostor);
+
+    expect((await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, seal)).status).toEqual(
+      VerificationStatus.FAIL,
+    );
+    expect(verifySpy).toHaveBeenCalledTimes(1);
+
+    expect((await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, seal)).status).toEqual(
+      VerificationStatus.FAIL,
+    );
+    expect(verifySpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/api/bft/UnicitySealQuorumSignaturesVerificationRuleTest.ts
+++ b/tests/unit/api/bft/UnicitySealQuorumSignaturesVerificationRuleTest.ts
@@ -1,5 +1,6 @@
 import { UnicitySeal } from '../../../../src/api/bft/UnicitySeal.js';
 import { UnicitySealQuorumSignaturesVerificationRule } from '../../../../src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.js';
+import { VerifiedSealCache } from '../../../../src/api/bft/verification/VerifiedSealCache.js';
 import { NetworkId } from '../../../../src/api/NetworkId.js';
 import { Secp256k1SignatureVerifier } from '../../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../../src/crypto/secp256k1/SigningService.js';
@@ -23,25 +24,35 @@ describe('UnicitySealQuorumSignaturesVerificationRule', () => {
 
   let signatureVerifier: Secp256k1SignatureVerifier;
   let verifySpy: jest.SpyInstance;
+  let rule: UnicitySealQuorumSignaturesVerificationRule;
 
   beforeEach(() => {
-    // A fresh verifier per test: the memo is keyed on the verifier instance, so
-    // this isolates each test from the others' cached verdicts.
     signatureVerifier = new Secp256k1SignatureVerifier();
     verifySpy = jest.spyOn(signatureVerifier, 'verify');
+    rule = new UnicitySealQuorumSignaturesVerificationRule(signatureVerifier, new VerifiedSealCache(256));
   });
 
   it('verifies a quorum seal, then serves the repeat from the memo', async () => {
     const trustBase = createRootTrustBase(rootNode.publicKey);
     const seal = await sealSignedBy(rootNode);
 
-    const first = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal);
+    const first = await rule.verify(trustBase, seal);
     expect(first.status).toEqual(VerificationStatus.OK);
     expect(verifySpy).toHaveBeenCalledTimes(1);
 
-    const second = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal);
+    const second = await rule.verify(trustBase, seal);
     expect(second.status).toEqual(VerificationStatus.OK);
     expect(verifySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('verifies every seal afresh when constructed without a cache', async () => {
+    const uncached = new UnicitySealQuorumSignaturesVerificationRule(signatureVerifier);
+    const trustBase = createRootTrustBase(rootNode.publicKey);
+    const seal = await sealSignedBy(rootNode);
+
+    expect((await uncached.verify(trustBase, seal)).status).toEqual(VerificationStatus.OK);
+    expect((await uncached.verify(trustBase, seal)).status).toEqual(VerificationStatus.OK);
+    expect(verifySpy).toHaveBeenCalledTimes(2);
   });
 
   // The memo must key on the seal's COMPLETE encoding, not on calculateHash():
@@ -57,12 +68,8 @@ describe('UnicitySealQuorumSignaturesVerificationRule', () => {
     // The trap: identical bodies, hence identical signature-excluding hashes.
     expect((await forged.calculateHash()).toString()).toEqual((await genuine.calculateHash()).toString());
 
-    expect(
-      (await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, genuine)).status,
-    ).toEqual(VerificationStatus.OK);
-
-    const result = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, forged);
-    expect(result.status).toEqual(VerificationStatus.FAIL);
+    expect((await rule.verify(trustBase, genuine)).status).toEqual(VerificationStatus.OK);
+    expect((await rule.verify(trustBase, forged)).status).toEqual(VerificationStatus.FAIL);
   });
 
   // The trust base is keyed by content, not identity: `_rootNodes` is an
@@ -73,32 +80,29 @@ describe('UnicitySealQuorumSignaturesVerificationRule', () => {
     const trustBase = createRootTrustBase(rootNode.publicKey);
     const seal = await sealSignedBy(rootNode);
 
-    expect(
-      (await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal)).status,
-    ).toEqual(VerificationStatus.OK);
+    expect((await rule.verify(trustBase, seal)).status).toEqual(VerificationStatus.OK);
     expect(verifySpy).toHaveBeenCalledTimes(1);
 
     // Swap the root node's key for one that did not sign this seal, mutating
     // the exposed Map in place exactly as an application could.
     trustBase._rootNodes.set('NODE', createRootTrustBase(impostor.publicKey)._rootNodes.get('NODE')!);
 
-    const result = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal);
-    expect(result.status).toEqual(VerificationStatus.FAIL);
+    expect((await rule.verify(trustBase, seal)).status).toEqual(VerificationStatus.FAIL);
     expect(verifySpy).toHaveBeenCalledTimes(2);
   });
 
-  it('does not memoise across signature verifiers, which need not agree', async () => {
+  it('keeps separate rules from sharing a memo', async () => {
     const trustBase = createRootTrustBase(rootNode.publicKey);
     const seal = await sealSignedBy(rootNode);
 
-    await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal);
+    await rule.verify(trustBase, seal);
     expect(verifySpy).toHaveBeenCalledTimes(1);
 
-    const other = new Secp256k1SignatureVerifier();
-    const otherSpy = jest.spyOn(other, 'verify');
-    const result = await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, other, seal);
+    const otherVerifier = new Secp256k1SignatureVerifier();
+    const otherSpy = jest.spyOn(otherVerifier, 'verify');
+    const otherRule = new UnicitySealQuorumSignaturesVerificationRule(otherVerifier, new VerifiedSealCache(256));
 
-    expect(result.status).toEqual(VerificationStatus.OK);
+    expect((await otherRule.verify(trustBase, seal)).status).toEqual(VerificationStatus.OK);
     expect(otherSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -106,14 +110,40 @@ describe('UnicitySealQuorumSignaturesVerificationRule', () => {
     const trustBase = createRootTrustBase(rootNode.publicKey);
     const seal = await sealSignedBy(impostor);
 
-    expect(
-      (await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal)).status,
-    ).toEqual(VerificationStatus.FAIL);
+    expect((await rule.verify(trustBase, seal)).status).toEqual(VerificationStatus.FAIL);
     expect(verifySpy).toHaveBeenCalledTimes(1);
 
-    expect(
-      (await UnicitySealQuorumSignaturesVerificationRule.verify(trustBase, signatureVerifier, seal)).status,
-    ).toEqual(VerificationStatus.FAIL);
+    expect((await rule.verify(trustBase, seal)).status).toEqual(VerificationStatus.FAIL);
     expect(verifySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the oldest entry once the cache is full', async () => {
+    const trustBase = createRootTrustBase(rootNode.publicKey);
+    const small = new UnicitySealQuorumSignaturesVerificationRule(signatureVerifier, new VerifiedSealCache(1));
+    const first = await sealSignedBy(rootNode);
+    const second = await UnicitySeal.create(
+      NetworkId.LOCAL,
+      1n,
+      0n,
+      0n,
+      null,
+      SEAL_CONTENT_HASH,
+      new Map([['NODE', rootNode]]),
+    );
+
+    await small.verify(trustBase, first);
+    await small.verify(trustBase, second);
+    expect(verifySpy).toHaveBeenCalledTimes(2);
+
+    // `first` was evicted by `second`, so it must be verified again.
+    await small.verify(trustBase, first);
+    expect(verifySpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('VerifiedSealCache', () => {
+  it('rejects a non-positive bound', () => {
+    expect(() => new VerifiedSealCache(0)).toThrow('VerifiedSealCache maxEntries must be a positive integer');
+    expect(() => new VerifiedSealCache(1.5)).toThrow('VerifiedSealCache maxEntries must be a positive integer');
   });
 });

--- a/tests/unit/crypto/secp256k1/SigningServiceVerifyTest.ts
+++ b/tests/unit/crypto/secp256k1/SigningServiceVerifyTest.ts
@@ -1,0 +1,78 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+
+import { DataHash } from '../../../../src/crypto/hash/DataHash.js';
+import { HashAlgorithm } from '../../../../src/crypto/hash/HashAlgorithm.js';
+import { Signature } from '../../../../src/crypto/secp256k1/Signature.js';
+import { SigningService } from '../../../../src/crypto/secp256k1/SigningService.js';
+
+const CURVE_ORDER = secp256k1.Point.Fn.ORDER;
+
+/**
+ * The malleable twin of a signature: `(r, n - s)` with the recovery bit
+ * flipped. It recovers to the same public key as the original, so key recovery
+ * alone cannot tell them apart — only a low-s check can.
+ */
+function malleableTwin(signature: Signature): Signature {
+  const parsed = secp256k1.Signature.fromBytes(signature.bytes, 'compact');
+  const twin = new secp256k1.Signature(parsed.r, CURVE_ORDER - parsed.s, signature.recovery ^ 1);
+
+  return new Signature(twin.toBytes('compact'), twin.recovery as number);
+}
+
+describe('SigningService.verifyWithPublicKey', () => {
+  const signingService = new SigningService(new Uint8Array(32).fill(0x0a));
+  const otherKey = new SigningService(new Uint8Array(32).fill(0x0b)).publicKey;
+  const hash = new DataHash(HashAlgorithm.SHA256, new Uint8Array(32).fill(0x0c));
+
+  let signature: Signature;
+
+  beforeAll(async () => {
+    signature = await signingService.sign(hash);
+  });
+
+  it('accepts a genuine signature under the signing key', async () => {
+    await expect(SigningService.verifyWithPublicKey(hash, signature, signingService.publicKey)).resolves.toBe(true);
+  });
+
+  it('rejects a genuine signature checked against a different key', async () => {
+    await expect(SigningService.verifyWithPublicKey(hash, signature, otherKey)).resolves.toBe(false);
+  });
+
+  it('rejects a signature over a different hash', async () => {
+    const otherHash = new DataHash(HashAlgorithm.SHA256, new Uint8Array(32).fill(0x0d));
+
+    await expect(SigningService.verifyWithPublicKey(otherHash, signature, signingService.publicKey)).resolves.toBe(
+      false,
+    );
+  });
+
+  it('rejects a tampered recovery byte', async () => {
+    const tampered = new Signature(signature.bytes, signature.recovery ^ 1);
+
+    await expect(SigningService.verifyWithPublicKey(hash, tampered, signingService.publicKey)).resolves.toBe(false);
+  });
+
+  // Key recovery accepts high-s signatures; noble's verify (lowS: true by
+  // default) did not. Verification here rests on recovery, so the low-s policy
+  // has to be enforced explicitly or signatures become malleable.
+  it('rejects the malleable high-s twin of a genuine signature', async () => {
+    const twin = malleableTwin(signature);
+
+    // The twin really is the same signature mathematically: it recovers to the
+    // same key, which is exactly why recovery alone cannot reject it.
+    expect(secp256k1.Signature.fromBytes(twin.bytes, 'compact').hasHighS()).toBe(true);
+    expect(
+      secp256k1.Signature.fromBytes(new Uint8Array([twin.recovery, ...twin.bytes]), 'recovered')
+        .recoverPublicKey(hash.data)
+        .toBytes(),
+    ).toEqual(signingService.publicKey);
+
+    await expect(SigningService.verifyWithPublicKey(hash, twin, signingService.publicKey)).resolves.toBe(false);
+  });
+
+  it('rejects a structurally invalid signature', async () => {
+    const garbage = new Signature(new Uint8Array(64), 0);
+
+    await expect(SigningService.verifyWithPublicKey(hash, garbage, signingService.publicKey)).resolves.toBe(false);
+  });
+});

--- a/tests/unit/predicate/builtin/verification/SignaturePredicateVerifierTest.ts
+++ b/tests/unit/predicate/builtin/verification/SignaturePredicateVerifierTest.ts
@@ -1,6 +1,7 @@
 import { DataHash } from '../../../../../src/crypto/hash/DataHash.js';
 import { DataHasher } from '../../../../../src/crypto/hash/DataHasher.js';
 import { HashAlgorithm } from '../../../../../src/crypto/hash/HashAlgorithm.js';
+import { Secp256k1SignatureVerifier } from '../../../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { Signature } from '../../../../../src/crypto/secp256k1/Signature.js';
 import { SigningService } from '../../../../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../../../../src/predicate/builtin/SignaturePredicate.js';
@@ -10,7 +11,7 @@ import { CborSerializer } from '../../../../../src/serialization/cbor/CborSerial
 import { VerificationStatus } from '../../../../../src/verification/VerificationStatus.js';
 
 describe('SignaturePredicateVerifier', () => {
-  const verifier = new SignaturePredicateVerifier();
+  const verifier = new SignaturePredicateVerifier(new Secp256k1SignatureVerifier());
   const signingService = SigningService.generate();
   const encodedPredicate = EncodedPredicate.fromPredicate(SignaturePredicate.fromSigningService(signingService));
 

--- a/tests/unit/util/InclusionProofUtilsTest.ts
+++ b/tests/unit/util/InclusionProofUtilsTest.ts
@@ -1,5 +1,6 @@
 import { getEventListeners } from 'node:events';
 
+import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationResponse } from '../../../src/api/CertificationResponse.js';
 import { IAggregatorClient } from '../../../src/api/IAggregatorClient.js';
 import { InclusionProof } from '../../../src/api/InclusionProof.js';
@@ -10,6 +11,7 @@ import { NetworkId } from '../../../src/api/NetworkId.js';
 import { StateId } from '../../../src/api/StateId.js';
 import { DataHash } from '../../../src/crypto/hash/DataHash.js';
 import { HashAlgorithm } from '../../../src/crypto/hash/HashAlgorithm.js';
+import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../../src/predicate/builtin/SignaturePredicate.js';
 import { PredicateVerifierService } from '../../../src/predicate/verification/PredicateVerifierService.js';
@@ -64,6 +66,7 @@ describe('waitInclusionProof', () => {
   const signingService = SigningService.generate();
   const trustBase = createRootTrustBase(signingService.publicKey);
   const predicateVerifier = PredicateVerifierService.create();
+  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
 
   let transaction: MintTransaction;
   let pendingProof: InclusionProof;
@@ -91,6 +94,7 @@ describe('waitInclusionProof', () => {
       new StateTransitionClient(aggregatorClient),
       trustBase,
       predicateVerifier,
+      unicityCertificateVerifier,
       transaction,
       signal,
       interval,

--- a/tests/unit/util/InclusionProofUtilsTest.ts
+++ b/tests/unit/util/InclusionProofUtilsTest.ts
@@ -1,6 +1,5 @@
 import { getEventListeners } from 'node:events';
 
-import { UnicityCertificateVerifier } from '../../../src/api/bft/verification/UnicityCertificateVerifier.js';
 import { CertificationResponse } from '../../../src/api/CertificationResponse.js';
 import { IAggregatorClient } from '../../../src/api/IAggregatorClient.js';
 import { InclusionProof } from '../../../src/api/InclusionProof.js';
@@ -11,7 +10,6 @@ import { NetworkId } from '../../../src/api/NetworkId.js';
 import { StateId } from '../../../src/api/StateId.js';
 import { DataHash } from '../../../src/crypto/hash/DataHash.js';
 import { HashAlgorithm } from '../../../src/crypto/hash/HashAlgorithm.js';
-import { Secp256k1SignatureVerifier } from '../../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../../src/predicate/builtin/SignaturePredicate.js';
 import { PredicateVerifierService } from '../../../src/predicate/verification/PredicateVerifierService.js';
@@ -22,6 +20,7 @@ import { TokenType } from '../../../src/transaction/TokenType.js';
 import { SleepError, waitInclusionProof } from '../../../src/util/InclusionProofUtils.js';
 import { createRootTrustBase } from '../../utils/RootTrustBaseFixture.js';
 import { createUnicityCertificate } from '../../utils/UnicityCertificateFixture.js';
+import { createUnicityCertificateVerifier } from '../../utils/UnicityCertificateVerifierFixture.js';
 
 interface IDeferred<T> {
   readonly promise: Promise<T>;
@@ -66,7 +65,7 @@ describe('waitInclusionProof', () => {
   const signingService = SigningService.generate();
   const trustBase = createRootTrustBase(signingService.publicKey);
   const predicateVerifier = PredicateVerifierService.create();
-  const unicityCertificateVerifier = new UnicityCertificateVerifier(new Secp256k1SignatureVerifier());
+  const unicityCertificateVerifier = createUnicityCertificateVerifier();
 
   let transaction: MintTransaction;
   let pendingProof: InclusionProof;

--- a/tests/utils/TokenUtils.ts
+++ b/tests/utils/TokenUtils.ts
@@ -47,10 +47,12 @@ export async function mintToken(
     await transaction.toCertifiedTransaction(
       verificationContext.trustBase,
       verificationContext.predicateVerifier,
+      verificationContext.unicityCertificateVerifier,
       await waitInclusionProof(
         client,
         verificationContext.trustBase,
         verificationContext.predicateVerifier,
+        verificationContext.unicityCertificateVerifier,
         transaction,
       ),
     ),
@@ -102,10 +104,12 @@ export async function transferTokenWithTransaction(
     await transaction.toCertifiedTransaction(
       verificationContext.trustBase,
       verificationContext.predicateVerifier,
+      verificationContext.unicityCertificateVerifier,
       await waitInclusionProof(
         client,
         verificationContext.trustBase,
         verificationContext.predicateVerifier,
+        verificationContext.unicityCertificateVerifier,
         transaction,
       ),
     ),

--- a/tests/utils/TransitionFlow.ts
+++ b/tests/utils/TransitionFlow.ts
@@ -1,7 +1,5 @@
 import { mintToken, transferToken } from './TokenUtils.js';
 import { RootTrustBase } from '../../src/api/bft/RootTrustBase.js';
-import { UnicityCertificateVerifier } from '../../src/api/bft/verification/UnicityCertificateVerifier.js';
-import { Secp256k1SignatureVerifier } from '../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../src/predicate/builtin/SignaturePredicate.js';
 import { PredicateVerifierService } from '../../src/predicate/verification/PredicateVerifierService.js';
@@ -10,6 +8,7 @@ import { MintJustificationVerifierService } from '../../src/transaction/verifica
 import { TokenIssuanceVerifierService } from '../../src/transaction/verification/TokenIssuanceVerifierService.js';
 import { VerificationContext } from '../../src/transaction/verification/VerificationContext.js';
 import { VerificationStatus } from '../../src/verification/VerificationStatus.js';
+import { createUnicityCertificateVerifier } from '../utils/UnicityCertificateVerifierFixture.js';
 
 export const transitionFlowTest = (client: StateTransitionClient, trustBase: RootTrustBase): void => {
   const ALICE_SIGNING_SERVICE = SigningService.generate();
@@ -22,7 +21,7 @@ export const transitionFlowTest = (client: StateTransitionClient, trustBase: Roo
       const verificationContext = new VerificationContext(
         trustBase,
         predicateVerifier,
-        new UnicityCertificateVerifier(new Secp256k1SignatureVerifier()),
+        createUnicityCertificateVerifier(),
         new MintJustificationVerifierService(),
         new TokenIssuanceVerifierService(false),
       );

--- a/tests/utils/TransitionFlow.ts
+++ b/tests/utils/TransitionFlow.ts
@@ -1,5 +1,7 @@
 import { mintToken, transferToken } from './TokenUtils.js';
 import { RootTrustBase } from '../../src/api/bft/RootTrustBase.js';
+import { UnicityCertificateVerifier } from '../../src/api/bft/verification/UnicityCertificateVerifier.js';
+import { Secp256k1SignatureVerifier } from '../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
 import { SigningService } from '../../src/crypto/secp256k1/SigningService.js';
 import { SignaturePredicate } from '../../src/predicate/builtin/SignaturePredicate.js';
 import { PredicateVerifierService } from '../../src/predicate/verification/PredicateVerifierService.js';
@@ -20,6 +22,7 @@ export const transitionFlowTest = (client: StateTransitionClient, trustBase: Roo
       const verificationContext = new VerificationContext(
         trustBase,
         predicateVerifier,
+        new UnicityCertificateVerifier(new Secp256k1SignatureVerifier()),
         new MintJustificationVerifierService(),
         new TokenIssuanceVerifierService(false),
       );

--- a/tests/utils/UnicityCertificateVerifierFixture.ts
+++ b/tests/utils/UnicityCertificateVerifierFixture.ts
@@ -1,0 +1,11 @@
+import { UnicitySealQuorumSignaturesVerificationRule } from '../../src/api/bft/verification/rule/UnicitySealQuorumSignaturesVerificationRule.js';
+import { UnicityCertificateVerifier } from '../../src/api/bft/verification/UnicityCertificateVerifier.js';
+import { VerifiedSealCache } from '../../src/api/bft/verification/VerifiedSealCache.js';
+import { Secp256k1SignatureVerifier } from '../../src/crypto/secp256k1/Secp256k1SignatureVerifier.js';
+
+/** The default production wiring: secp256k1 signatures, seals memoised. */
+export function createUnicityCertificateVerifier(): UnicityCertificateVerifier {
+  return new UnicityCertificateVerifier(
+    new UnicitySealQuorumSignaturesVerificationRule(new Secp256k1SignatureVerifier(), new VerifiedSealCache(256)),
+  );
+}


### PR DESCRIPTION
> **Implements #142** — the analysis, the measurements and the cache-key requirement are from that issue.
>
> Now rebased onto the **pluggable signature verification** design from #142's comment: `ISignatureVerifier` / `Secp256k1SignatureVerifier`, `UnicityCertificateVerifier` threaded through the verification chain, `verifyWithRecoveredPublicKey` removed. See the second commit.

---

Inclusion-proof verification is dominated by secp256k1 work. Two of those costs are avoidable, and together they account for most of the per-entry verification time measured in unicity-sphere/wallet-api#120 (~187 ms/entry on staging, roughly half of a large transfer's wall-clock).

## 1. `SigningService.verifyWithPublicKey` did two EC operations where one suffices

It recovered the public key from the signature, compared it against the expected key, and then verified the signature *again*. Recovery already establishes validity: the recovered key is by construction the only key under which `(r, s)` verifies for that hash, so if it equals the expected key the signature is valid.

The second call was not entirely redundant, though — it supplied noble's default `lowS: true` policy. Dropping it naively would have made signatures malleable, so the low-s check is now explicit. `SigningServiceVerifyTest` pins this: it builds the malleable twin `(r, n - s)` with the recovery bit flipped, asserts it recovers to *the same public key* (which is why recovery alone cannot reject it), and requires `verifyWithPublicKey` to return false.

## 2. Every seal was re-verified once per inclusion proof

All leaves certified in the same aggregator round share one `UnicitySeal`, but each proof verified its seal from scratch. On testnet2 a seal carries 4 signatures and `verifyWithPublicKey` runs per signature, so a 20-proof batch spent ~80 signature verifications on ~3 distinct seals. Verified seals are now memoised per trust base.

### The cache key is over the seal's complete encoding, deliberately

`UnicitySeal.calculateHash()` excludes the signatures — necessarily, since it is the digest the root nodes sign. **A cache keyed on it would be a vulnerability:** two seals with the same body but different signatures share that hash, so an attacker could take a seal that had verified, swap its signatures for garbage, and be served a cached `OK` without those signatures ever being checked.

The key here is the hash of `toCBOR()`, which encodes the signatures too, so a hit means byte-identical input. `UnicitySealQuorumSignaturesVerificationRuleTest` covers this directly: it verifies a genuine seal, then submits one with an identical body signed by a key outside the trust base — asserting first that the two share a `calculateHash()` (i.e. the test really does exercise the trap) and then that the forged seal is rejected.

Two further properties: the trust base is part of the key by instance identity (a `WeakMap`, so a different trust base misses rather than inherits), and only quorum-reaching outcomes are cached, so a stream of invalid seals cannot evict good entries. The cache is bounded at 256 seals per trust base.

## Measured

Same box, testnet2 shape (4 root nodes, quorum 3, 4 signatures per seal):

| | before | after | |
|---|---|---|---|
| `verifyWithPublicKey` | 5.683 ms/op | 2.971 ms/op | −48% |
| 20 proofs sharing 3 seals | 490.7 ms | 50.9 ms | −90% |

Both paths benefit: wallet-api's deposit validation and every wallet's client-side proof verification.

## Verification

- `npm run lint` — clean
- `npm run build:check` — clean
- `npm run test` — 28 suites, 146 tests, all passing (10 new)
- Mutation-checked: reverting the low-s check fails exactly the malleability test; keying the cache on `calculateHash()` fails exactly the signature-swap test.

Not included: short-circuiting at quorum (verify 3 of 4 rather than all 4). It is worth ~25% of seal cost, but with memoisation seal verification is now rare enough that it is no longer the place to spend.

Closes #142
Refs unicity-sphere/wallet-api#120




## Update — rebased onto the #142 seam

The signature-verification half now lives where the design puts it:

- `ISignatureVerifier<T>` (low-level seam) + `Secp256k1SignatureVerifier` (default implementation, owning the recover-and-compare semantics and the explicit low-s check).
- `SigningService` composes the verifier and delegates; its statics stay as thin delegates. `verifyWithRecoveredPublicKey` had no callers and is removed.
- `UnicityCertificateVerification` → `UnicityCertificateVerifier`, an instance class owning the `ISignatureVerifier`, threaded through `IVerificationContext`/`VerificationContext`, `InclusionProofVerificationRule`, the certified-transaction rules and factories, `toCertifiedTransaction`, and `waitInclusionProof`. Worker verifiers gain the abstract `unicityCertificateVerifier` getter.
- `SignaturePredicateVerifier` takes the verifier as a required constructor argument; `DefaultBuiltInPredicateVerifier.create()` wires secp256k1.

Two consequences for the memo, both in the second commit:

1. **It is keyed on the verifier too.** Pluggable verifiers need not agree — one binding the recovery byte rejects signatures that one checking only `(r, s)` accepts — so a verdict must not leak across that boundary.
2. **The trust base is keyed by content, not instance identity** (addresses the Codex review comment). `RootTrustBase` exposes `_rootNodes` as a `Map` and `readonly` stops only reassignment, so an in-place edit of the root keys would otherwise keep hitting verdicts computed under the old ones. A test mutates the map and asserts re-verification.

Measurements are unchanged by the refactor: `verifyWithPublicKey` 5.683 → 2.946 ms/op; 20 proofs sharing 3 seals 490.7 → 52.0 ms.

Verification: `npm run lint` clean, `npm run build:check` clean, `npm run test` 28 suites / 147 tests passing. All three security properties are mutation-checked — removing the low-s check, keying the memo on `calculateHash()`, or keying the trust base by identity each fails exactly its own test.
